### PR TITLE
fix: meme editor doesn't reset

### DIFF
--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -269,6 +269,7 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 	const textStyle = useMemeEditorStore((state) => state.textStyle);
 	const addTextboxToStore = useMemeEditorStore((state) => state.addTextbox);
 	const addImageToStore = useMemeEditorStore((state) => state.addImage);
+	const resetEditor = useMemeEditorStore((state) => state.resetEditor);
 	const [backgroundImage, setBackgroundImage] =
 		useState<HTMLImageElement | null>(null);
 	const canvasRef = useRef<CanvasHandle>(null);
@@ -284,6 +285,8 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 	useEffect(() => {
 		const controller = new AbortController();
 		let objectUrl = "";
+		setBackgroundImage(null);
+		resetEditor();
 
 		const hydrateBackground = async () => {
 			try {
@@ -320,7 +323,7 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 				URL.revokeObjectURL(objectUrl);
 			}
 		};
-	}, [background]);
+	}, [background, resetEditor]);
 
 	if (!backgroundImage) {
 		return <p>Loading canvas...</p>;

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -13,10 +13,14 @@ import {
 	type TextStyle,
 } from "./types";
 
-type MemeEditorStore = {
+type MemeEditorState = {
 	textboxes: Textbox[];
 	images: EditorImage[];
 	textStyle: TextStyle;
+};
+
+type MemeEditorStore = MemeEditorState & {
+	resetEditor: () => void;
 	addTextbox: (textbox: Textbox) => void;
 	addImage: (image: EditorImage) => void;
 	setTextboxText: (id: string, text: string) => void;
@@ -59,7 +63,7 @@ const applyTextboxTransform = (
 	};
 };
 
-export const useMemeEditorStore = create<MemeEditorStore>((set) => ({
+const createInitialState = (): MemeEditorState => ({
 	textboxes: [],
 	images: [],
 	textStyle: {
@@ -69,6 +73,11 @@ export const useMemeEditorStore = create<MemeEditorStore>((set) => ({
 		strokeWidth: DEFAULT_STROKE_WIDTH,
 		shadowBlur: DEFAULT_SHADOW_BLUR,
 	},
+});
+
+export const useMemeEditorStore = create<MemeEditorStore>((set) => ({
+	...createInitialState(),
+	resetEditor: () => set(createInitialState()),
 	addTextbox: (textbox) =>
 		set((state) => ({
 			textboxes: [...state.textboxes, textbox],


### PR DESCRIPTION
There's currently a bug with the meme editor where you edit one template, then you open another template and the editor state is stale from the previous template. This is because we don't reset the store.

I have updated the editor to reset before we set the background image, so now we will reset whenever the template changes.

I validated that any textboxes, images, and text style changes are reset when opening a new template.