### PR TITLE
minor: add editor preview scale

### DIFF
--- a/frontend/src/components/MemeEditor/Canvas.tsx
+++ b/frontend/src/components/MemeEditor/Canvas.tsx
@@ -24,14 +24,6 @@ import {
 	type TextboxHandlers,
 } from "./types";
 
-type CanvasProps = {
-	backgroundImage: HTMLImageElement;
-	ref: Ref<CanvasHandle>;
-};
-export type CanvasHandle = {
-	exportBlob: () => Promise<Blob>;
-};
-
 const syncTransformerSelection = (
 	transformer: Konva.Transformer | null,
 	selectedNodeKey: NodeKey | null,
@@ -119,6 +111,7 @@ const setNodeRef = (
 const exportStageImageBlob = async (
 	stage: Konva.Stage,
 	transformer: Konva.Transformer | null,
+	exportPixelRatio: number,
 ) => {
 	const selectedNodes = transformer?.nodes() ?? [];
 	try {
@@ -129,7 +122,7 @@ const exportStageImageBlob = async (
 
 		const exportedBlob = await stage.toBlob({
 			mimeType: IMAGE_MIME_TYPE,
-			pixelRatio: 1,
+			pixelRatio: exportPixelRatio,
 		});
 		if (!(exportedBlob instanceof Blob)) {
 			throw new Error("Failed to export canvas as image");
@@ -144,7 +137,17 @@ const exportStageImageBlob = async (
 	}
 };
 
-export const Canvas = ({ backgroundImage, ref }: CanvasProps) => {
+export type CanvasHandle = {
+	exportBlob: () => Promise<Blob>;
+};
+
+export type CanvasProps = {
+	backgroundImage: HTMLImageElement;
+	previewScale: number;
+	ref: Ref<CanvasHandle>;
+};
+
+export const Canvas = ({ backgroundImage, previewScale, ref }: CanvasProps) => {
 	const textboxes = useMemeEditorStore((state) => state.textboxes);
 	const images = useMemeEditorStore((state) => state.images);
 	const setTextboxText = useMemeEditorStore((state) => state.setTextboxText);
@@ -159,6 +162,15 @@ export const Canvas = ({ backgroundImage, ref }: CanvasProps) => {
 	const stageRef = useRef<Konva.Stage | null>(null);
 	const transformerRef = useRef<Konva.Transformer | null>(null);
 	const nodeRefs = useRef<Map<NodeKey, Konva.Node>>(new Map());
+	const exportPixelRatio = 1 / previewScale;
+	const stageWidth = Math.max(
+		1,
+		Math.round(backgroundImage.naturalWidth * previewScale),
+	);
+	const stageHeight = Math.max(
+		1,
+		Math.round(backgroundImage.naturalHeight * previewScale),
+	);
 
 	const exportBlob = useCallback<() => Promise<Blob>>(async () => {
 		const stage = stageRef.current;
@@ -167,8 +179,8 @@ export const Canvas = ({ backgroundImage, ref }: CanvasProps) => {
 			throw new Error("Stage is not ready");
 		}
 
-		return exportStageImageBlob(stage, transformer);
-	}, []);
+		return exportStageImageBlob(stage, transformer, exportPixelRatio);
+	}, [exportPixelRatio]);
 
 	useImperativeHandle(
 		ref,
@@ -213,8 +225,10 @@ export const Canvas = ({ backgroundImage, ref }: CanvasProps) => {
 	return (
 		<Stage
 			ref={stageRef}
-			width={backgroundImage.naturalWidth}
-			height={backgroundImage.naturalHeight}
+			width={stageWidth}
+			height={stageHeight}
+			scaleX={previewScale}
+			scaleY={previewScale}
 			onMouseDown={(event) => {
 				if (isStageBackgroundClick(event)) {
 					setSelectedNodeKey(null);

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -3,6 +3,7 @@ import {
 	type MouseEvent,
 	useCallback,
 	useEffect,
+	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -12,6 +13,8 @@ import {
 	createEditorImage,
 	createTextbox,
 	getCanvasMiddlePosition,
+	getDefaultFontSize,
+	getPreviewScale,
 } from "./translation";
 import type { BackgroundSource, TextAlignment, TextStyle } from "./types";
 import { IMAGE_MIME_TYPE } from "./types";
@@ -22,27 +25,48 @@ export type MemeEditorProps = {
 
 const textAlignments: TextAlignment[] = ["center", "left", "right"];
 
-const loadImage = (url: string) =>
-	new Promise<HTMLImageElement>((resolve, reject) => {
+const loadImage = (url: string) => {
+	return new Promise<HTMLImageElement>((resolve, reject) => {
 		const image = new window.Image();
 		image.onload = () => resolve(image);
 		image.onerror = () => reject(new Error(`Failed to load image from ${url}`));
 		image.src = url;
 	});
+};
 
-const TextSizeInput = () => {
+type TextSizeInputProps = {
+	previewScale: number;
+};
+
+const TextSizeInput = ({ previewScale }: TextSizeInputProps) => {
 	const value = useMemeEditorStore((state) => state.textStyle.fontSize);
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const displayValue = Math.max(1, Math.round(value * previewScale));
+
+	const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+		// round text size to nearest int
+		const inputSize = Math.round(Number(event.target.value));
+		const isValidNumber = Number.isFinite(inputSize) && inputSize > 0;
+
+		// clamp display size to 1 if input is invalid
+		const clampedDisplaySize = isValidNumber ? inputSize : 1;
+
+		// convert display size to actual size
+		const actualSize = Math.max(
+			1,
+			Math.round(clampedDisplaySize / previewScale),
+		);
+
+		setTextStyle("fontSize", actualSize);
+	};
 
 	return (
 		<label>
 			Text size
 			<input
 				type="number"
-				value={value}
-				onChange={(event) =>
-					setTextStyle("fontSize", Math.round(Number(event.target.value)))
-				}
+				value={displayValue}
+				onChange={handleChange}
 			/>
 		</label>
 	);
@@ -270,6 +294,7 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 	const addTextboxToStore = useMemeEditorStore((state) => state.addTextbox);
 	const addImageToStore = useMemeEditorStore((state) => state.addImage);
 	const resetEditor = useMemeEditorStore((state) => state.resetEditor);
+	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
 	const [backgroundImage, setBackgroundImage] =
 		useState<HTMLImageElement | null>(null);
 	const canvasRef = useRef<CanvasHandle>(null);
@@ -325,6 +350,18 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 		};
 	}, [background, resetEditor]);
 
+	const previewScale = useMemo(() => {
+		if (!backgroundImage) {
+			return 1;
+		}
+		return getPreviewScale(backgroundImage);
+	}, [backgroundImage]);
+
+	useEffect(() => {
+		const defaultActualFontSize = getDefaultFontSize(previewScale);
+		setTextStyle("fontSize", defaultActualFontSize);
+	}, [previewScale, setTextStyle]);
+
 	if (!backgroundImage) {
 		return <p>Loading canvas...</p>;
 	}
@@ -333,29 +370,44 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 		<>
 			<form>
 				<div className="grid">
-					<TextSizeInput />
-					<TextColorInput />
-					<TextAlignmentInput />
+					<div className="grid">
+						<AddImageButton
+							backgroundImage={backgroundImage}
+							onAddImage={addImageToStore}
+						/>
+						<AddTextboxButton
+							backgroundImage={backgroundImage}
+							textStyle={textStyle}
+							onAddTextbox={addTextboxToStore}
+						/>
+					</div>
+					<div></div>
 				</div>
 				<div className="grid">
-					<OutlineWidthInput />
-					<ShadowStrengthInput />
-				</div>
-				<div className="grid">
-					<AddImageButton
-						backgroundImage={backgroundImage}
-						onAddImage={addImageToStore}
-					/>
-					<AddTextboxButton
-						backgroundImage={backgroundImage}
-						textStyle={textStyle}
-						onAddTextbox={addTextboxToStore}
-					/>
-					<DownloadMemeButton getMemeBlob={downloadBlob} />
-					<CopyMemeButton getMemeBlob={downloadBlob} />
+					<div>
+						<Canvas
+							ref={canvasRef}
+							backgroundImage={backgroundImage}
+							previewScale={previewScale}
+						/>
+					</div>
+					<div>
+						<div className="grid">
+							<TextSizeInput previewScale={previewScale} />
+							<TextColorInput />
+							<TextAlignmentInput />
+						</div>
+						<div className="grid">
+							<OutlineWidthInput />
+							<ShadowStrengthInput />
+						</div>
+					</div>
 				</div>
 			</form>
-			<Canvas ref={canvasRef} backgroundImage={backgroundImage} />
+			<div className="grid">
+				<DownloadMemeButton getMemeBlob={downloadBlob} />
+				<CopyMemeButton getMemeBlob={downloadBlob} />
+			</div>
 		</>
 	);
 };

--- a/frontend/src/components/MemeEditor/translation.tsx
+++ b/frontend/src/components/MemeEditor/translation.tsx
@@ -3,12 +3,15 @@ import type { JSX } from "react";
 import { Image as KonvaImage, Text } from "react-konva";
 import { randomID } from "../../util/util";
 import {
+	DEFAULT_DISPLAY_FONT_SIZE,
 	DEFAULT_FONT_FAMILY,
 	DEFAULT_ROTATION,
 	DEFAULT_SECONDARY_TEXT_COLOR,
 	DEFAULT_TEXT,
 	DEFAULT_X_OFFSET,
 	DEFAULT_Y_OFFSET,
+	EDITOR_PREVIEW_MAX_HEIGHT,
+	EDITOR_PREVIEW_MAX_WIDTH,
 	type EditorImage,
 	type ImageHandlers,
 	type KeyType,
@@ -25,6 +28,16 @@ const MIN_FONT_SIZE = 8;
 const MIN_IMAGE_WIDTH = 20;
 const MIN_IMAGE_HEIGHT = 20;
 const DEFAULT_IMAGE_SCALE = 0.25;
+
+export const getPreviewScale = (backgroundImage: HTMLImageElement) => {
+	const widthScale = EDITOR_PREVIEW_MAX_WIDTH / backgroundImage.naturalWidth;
+	const heightScale = EDITOR_PREVIEW_MAX_HEIGHT / backgroundImage.naturalHeight;
+	return Math.min(widthScale, heightScale, 1);
+};
+
+export const getDefaultFontSize = (previewScale: number) => {
+	return Math.max(1, Math.round(DEFAULT_DISPLAY_FONT_SIZE / previewScale));
+};
 
 export const createNodeKey = (keyType: KeyType, id: string): NodeKey =>
 	`${keyType}:${id}`;

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -1,5 +1,8 @@
 import type Konva from "konva";
 
+export const EDITOR_PREVIEW_MAX_WIDTH = 525;
+export const EDITOR_PREVIEW_MAX_HEIGHT = 550;
+export const DEFAULT_DISPLAY_FONT_SIZE = 50;
 export const DEFAULT_TEXT = "Enter text";
 export const DEFAULT_X_OFFSET = -100;
 export const DEFAULT_Y_OFFSET = 0;


### PR DESCRIPTION
Currently the meme editor adds the selected template as the canvas background image, using the original image resolution. This is not a good editor experience since it makes the image take up a huge amount of space on the screen.

I have updated the editor to scale the image and display the inputs next to the scaled preview. When copying to clipboard or downloading, we export the image at the original size.

Since the font size looks really big when using the scaled canvas, I also use a "display" font size in the input that is actually a scaled version of the actual font size.