### PR TITLE
minor: allow styling individual textboxes

### DIFF
--- a/frontend/src/components/MemeEditor/Canvas.tsx
+++ b/frontend/src/components/MemeEditor/Canvas.tsx
@@ -157,6 +157,9 @@ export const Canvas = ({ backgroundImage, previewScale, ref }: CanvasProps) => {
 	const setImageTransform = useMemeEditorStore(
 		(state) => state.setImageTransform,
 	);
+	const setSelectedTextboxId = useMemeEditorStore(
+		(state) => state.setSelectedTextboxId,
+	);
 
 	const [selectedNodeKey, setSelectedNodeKey] = useState<NodeKey | null>(null);
 	const stageRef = useRef<Konva.Stage | null>(null);
@@ -201,6 +204,17 @@ export const Canvas = ({ backgroundImage, previewScale, ref }: CanvasProps) => {
 	useEffect(() => {
 		clearStaleSelection(selectedNodeKey, textboxes, images, setSelectedNodeKey);
 	}, [selectedNodeKey, textboxes, images]);
+
+	useEffect(() => {
+		if (!selectedNodeKey) {
+			setSelectedTextboxId(null);
+			return;
+		}
+
+		const { keyType, id } = parseNodeKey(selectedNodeKey);
+		const selectedTextboxId = keyType === "text" ? id : null;
+		setSelectedTextboxId(selectedTextboxId);
+	}, [selectedNodeKey, setSelectedTextboxId]);
 
 	const textboxHandlers: TextboxHandlers = {
 		onEditTextbox: (id) => editTextbox({ textboxes, setTextboxText, id }),

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -16,7 +16,12 @@ import {
 	getDefaultFontSize,
 	getPreviewScale,
 } from "./translation";
-import type { BackgroundSource, TextAlignment, TextStyle } from "./types";
+import type {
+	BackgroundSource,
+	TextAlignment,
+	TextStyle,
+	TextStyleScope,
+} from "./types";
 import { IMAGE_MIME_TYPE } from "./types";
 
 export type MemeEditorProps = {
@@ -149,6 +154,31 @@ const ShadowStrengthInput = () => {
 					setTextStyle("shadowBlur", Number(event.target.value))
 				}
 			/>
+		</label>
+	);
+};
+
+const TextStyleScopeInput = () => {
+	const value = useMemeEditorStore((state) => state.textStyleScope);
+	const setTextStyleScope = useMemeEditorStore(
+		(state) => state.setTextStyleScope,
+	);
+
+	const onToggle = (event: ChangeEvent<HTMLInputElement>) => {
+		const nextScope: TextStyleScope = event.target.checked ? "all" : "selected";
+		setTextStyleScope(nextScope);
+	};
+
+		return (
+			<label>
+				<input
+					type="checkbox"
+					role="switch"
+					aria-checked={value === "all"}
+					checked={value === "all"}
+					onChange={onToggle}
+				/>
+				Apply styles to all textboxes
 		</label>
 	);
 };
@@ -392,6 +422,7 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 						/>
 					</div>
 					<div>
+						<TextStyleScopeInput />
 						<div className="grid">
 							<TextSizeInput previewScale={previewScale} />
 							<TextColorInput />

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -44,8 +44,8 @@ type TextSizeInputProps = {
 };
 
 const TextSizeInput = ({ previewScale }: TextSizeInputProps) => {
-	const value = useMemeEditorStore((state) => state.textStyle.fontSize);
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const value = useMemeEditorStore((state) => state.getTextStyle("fontSize"));
 	const displayValue = Math.max(1, Math.round(value * previewScale));
 
 	const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -68,18 +68,14 @@ const TextSizeInput = ({ previewScale }: TextSizeInputProps) => {
 	return (
 		<label>
 			Text size
-			<input
-				type="number"
-				value={displayValue}
-				onChange={handleChange}
-			/>
+			<input type="number" value={displayValue} onChange={handleChange} />
 		</label>
 	);
 };
 
 const TextColorInput = () => {
-	const value = useMemeEditorStore((state) => state.textStyle.fill);
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const value = useMemeEditorStore((state) => state.getTextStyle("fill"));
 
 	return (
 		<label>
@@ -94,8 +90,8 @@ const TextColorInput = () => {
 };
 
 const TextAlignmentInput = () => {
-	const value = useMemeEditorStore((state) => state.textStyle.textAlign);
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const value = useMemeEditorStore((state) => state.getTextStyle("textAlign"));
 
 	return (
 		<label>
@@ -117,8 +113,10 @@ const TextAlignmentInput = () => {
 };
 
 const OutlineWidthInput = () => {
-	const value = useMemeEditorStore((state) => state.textStyle.strokeWidth);
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const value = useMemeEditorStore((state) =>
+		state.getTextStyle("strokeWidth"),
+	);
 
 	return (
 		<label>
@@ -138,8 +136,8 @@ const OutlineWidthInput = () => {
 };
 
 const ShadowStrengthInput = () => {
-	const value = useMemeEditorStore((state) => state.textStyle.shadowBlur);
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const value = useMemeEditorStore((state) => state.getTextStyle("shadowBlur"));
 
 	return (
 		<label>
@@ -165,20 +163,22 @@ const TextStyleScopeInput = () => {
 	);
 
 	const onToggle = (event: ChangeEvent<HTMLInputElement>) => {
-		const nextScope: TextStyleScope = event.target.checked ? "all" : "selected";
+		const nextScope: TextStyleScope = event.target.checked
+			? "global"
+			: "selected";
 		setTextStyleScope(nextScope);
 	};
 
-		return (
-			<label>
-				<input
-					type="checkbox"
-					role="switch"
-					aria-checked={value === "all"}
-					checked={value === "all"}
-					onChange={onToggle}
-				/>
-				Apply styles to all textboxes
+	return (
+		<label>
+			<input
+				type="checkbox"
+				role="switch"
+				aria-checked={value === "global"}
+				checked={value === "global"}
+				onChange={onToggle}
+			/>
+			Apply styles to all textboxes
 		</label>
 	);
 };
@@ -320,7 +320,7 @@ const CopyMemeButton = ({ getMemeBlob }: CopyMemeButtonProps) => {
 };
 
 export const MemeEditor = ({ background }: MemeEditorProps) => {
-	const textStyle = useMemeEditorStore((state) => state.textStyle);
+	const globalTextStyle = useMemeEditorStore((state) => state.globalTextStyle);
 	const addTextboxToStore = useMemeEditorStore((state) => state.addTextbox);
 	const addImageToStore = useMemeEditorStore((state) => state.addImage);
 	const resetEditor = useMemeEditorStore((state) => state.resetEditor);
@@ -407,7 +407,7 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 						/>
 						<AddTextboxButton
 							backgroundImage={backgroundImage}
-							textStyle={textStyle}
+							textStyle={globalTextStyle}
 							onAddTextbox={addTextboxToStore}
 						/>
 					</div>

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -324,7 +324,9 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 	const addTextboxToStore = useMemeEditorStore((state) => state.addTextbox);
 	const addImageToStore = useMemeEditorStore((state) => state.addImage);
 	const resetEditor = useMemeEditorStore((state) => state.resetEditor);
-	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const setDefaultFontSize = useMemeEditorStore(
+		(state) => state.setDefaultFontSize,
+	);
 	const [backgroundImage, setBackgroundImage] =
 		useState<HTMLImageElement | null>(null);
 	const canvasRef = useRef<CanvasHandle>(null);
@@ -388,9 +390,9 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 	}, [backgroundImage]);
 
 	useEffect(() => {
-		const defaultActualFontSize = getDefaultFontSize(previewScale);
-		setTextStyle("fontSize", defaultActualFontSize);
-	}, [previewScale, setTextStyle]);
+		const defaultFontSize = getDefaultFontSize(previewScale);
+		setDefaultFontSize(defaultFontSize);
+	}, [previewScale, setDefaultFontSize]);
 
 	if (!backgroundImage) {
 		return <p>Loading canvas...</p>;

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -162,24 +162,33 @@ const TextStyleScopeInput = () => {
 		(state) => state.setTextStyleScope,
 	);
 
-	const onToggle = (event: ChangeEvent<HTMLInputElement>) => {
-		const nextScope: TextStyleScope = event.target.checked
-			? "global"
-			: "selected";
+	const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+		const nextScope = event.target.value as TextStyleScope;
 		setTextStyleScope(nextScope);
 	};
 
 	return (
-		<label>
+		<fieldset>
+			<legend>Apply text styles to</legend>
 			<input
-				type="checkbox"
-				role="switch"
-				aria-checked={value === "global"}
+				type="radio"
+				id="text-style-scope-global"
+				name="text-style-scope"
+				value="global"
 				checked={value === "global"}
-				onChange={onToggle}
+				onChange={onChange}
 			/>
-			Apply styles to all textboxes
-		</label>
+			<label htmlFor="text-style-scope-global">All</label>
+			<input
+				type="radio"
+				id="text-style-scope-selected"
+				name="text-style-scope"
+				value="selected"
+				checked={value === "selected"}
+				onChange={onChange}
+			/>
+			<label htmlFor="text-style-scope-selected">Selected</label>
+		</fieldset>
 	);
 };
 

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -7,6 +7,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import { Tooltip } from "../Tooltip";
 import { Canvas, type CanvasHandle } from "./Canvas";
 import { useMemeEditorStore } from "./store";
 import {
@@ -39,14 +40,30 @@ const loadImage = (url: string) => {
 	});
 };
 
-type TextSizeInputProps = {
-	previewScale: number;
+const getDeactivatedReason = (
+	textStyleScope: TextStyleScope,
+	selectedTextboxId: string | null,
+) => {
+	if (textStyleScope === "selected" && selectedTextboxId === null) {
+		return "No textbox selected";
+	}
+
+	return "";
 };
 
-const TextSizeInput = ({ previewScale }: TextSizeInputProps) => {
+type TextSizeInputProps = {
+	previewScale: number;
+	disabledReason: string;
+};
+
+const TextSizeInput = ({
+	previewScale,
+	disabledReason,
+}: TextSizeInputProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
 	const value = useMemeEditorStore((state) => state.getTextStyle("fontSize"));
 	const displayValue = Math.max(1, Math.round(value * previewScale));
+	const disabled = disabledReason !== "";
 
 	const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
 		// round text size to nearest int
@@ -66,93 +83,132 @@ const TextSizeInput = ({ previewScale }: TextSizeInputProps) => {
 	};
 
 	return (
-		<label>
-			Text size
-			<input type="number" value={displayValue} onChange={handleChange} />
-		</label>
+		<Tooltip message={disabledReason} active={disabled}>
+			<label>
+				Text size
+				<input
+					type="number"
+					value={displayValue}
+					onChange={handleChange}
+					disabled={disabled}
+				/>
+			</label>
+		</Tooltip>
 	);
 };
 
-const TextColorInput = () => {
+type TextColorInputProps = {
+	disabledReason: string;
+};
+
+const TextColorInput = ({ disabledReason }: TextColorInputProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
 	const value = useMemeEditorStore((state) => state.getTextStyle("fill"));
+	const disabled = disabledReason !== "";
 
 	return (
-		<label>
-			Text color
-			<input
-				type="color"
-				value={value}
-				onChange={(event) => setTextStyle("fill", event.target.value)}
-			/>
-		</label>
+		<Tooltip message={disabledReason} active={disabled}>
+			<label>
+				Text color
+				<input
+					type="color"
+					value={value}
+					onChange={(event) => setTextStyle("fill", event.target.value)}
+					disabled={disabled}
+				/>
+			</label>
+		</Tooltip>
 	);
 };
 
-const TextAlignmentInput = () => {
+type TextAlignmentInputProps = {
+	disabledReason: string;
+};
+
+const TextAlignmentInput = ({ disabledReason }: TextAlignmentInputProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
 	const value = useMemeEditorStore((state) => state.getTextStyle("textAlign"));
+	const disabled = disabledReason !== "";
 
 	return (
-		<label>
-			Text alignment
-			<select
-				value={value}
-				onChange={(event) =>
-					setTextStyle("textAlign", event.target.value as TextAlignment)
-				}
-			>
-				{textAlignments.map((alignment) => (
-					<option value={alignment} key={alignment}>
-						{alignment}
-					</option>
-				))}
-			</select>
-		</label>
+		<Tooltip message={disabledReason} active={disabled}>
+			<label>
+				Text alignment
+				<select
+					value={value}
+					onChange={(event) =>
+						setTextStyle("textAlign", event.target.value as TextAlignment)
+					}
+					disabled={disabled}
+				>
+					{textAlignments.map((alignment) => (
+						<option value={alignment} key={alignment}>
+							{alignment}
+						</option>
+					))}
+				</select>
+			</label>
+		</Tooltip>
 	);
 };
 
-const OutlineWidthInput = () => {
+type OutlineWidthInputProps = {
+	disabledReason: string;
+};
+
+const OutlineWidthInput = ({ disabledReason }: OutlineWidthInputProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
 	const value = useMemeEditorStore((state) =>
 		state.getTextStyle("strokeWidth"),
 	);
+	const disabled = disabledReason !== "";
 
 	return (
-		<label>
-			Outline width: {value}
-			<input
-				type="range"
-				min="0.5"
-				max="10"
-				step="0.5"
-				value={value}
-				onChange={(event) =>
-					setTextStyle("strokeWidth", Number(event.target.value))
-				}
-			/>
-		</label>
+		<Tooltip message={disabledReason} active={disabled}>
+			<label>
+				Outline width: {value}
+				<input
+					type="range"
+					min="0.5"
+					max="10"
+					step="0.5"
+					value={value}
+					onChange={(event) =>
+						setTextStyle("strokeWidth", Number(event.target.value))
+					}
+					disabled={disabled}
+				/>
+			</label>
+		</Tooltip>
 	);
 };
 
-const ShadowStrengthInput = () => {
+type ShadowStrengthInputProps = {
+	disabledReason: string;
+};
+
+const ShadowStrengthInput = ({ disabledReason }: ShadowStrengthInputProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
 	const value = useMemeEditorStore((state) => state.getTextStyle("shadowBlur"));
+	const disabled = disabledReason !== "";
 
 	return (
-		<label>
-			Shadow strength: {value}
-			<input
-				type="range"
-				min="0"
-				max="50"
-				step="1"
-				value={value}
-				onChange={(event) =>
-					setTextStyle("shadowBlur", Number(event.target.value))
-				}
-			/>
-		</label>
+		<Tooltip message={disabledReason} active={disabled}>
+			<label>
+				Shadow strength: {value}
+				<input
+					type="range"
+					min="0"
+					max="50"
+					step="1"
+					value={value}
+					onChange={(event) =>
+						setTextStyle("shadowBlur", Number(event.target.value))
+					}
+					disabled={disabled}
+				/>
+			</label>
+		</Tooltip>
 	);
 };
 
@@ -330,6 +386,10 @@ const CopyMemeButton = ({ getMemeBlob }: CopyMemeButtonProps) => {
 
 export const MemeEditor = ({ background }: MemeEditorProps) => {
 	const globalTextStyle = useMemeEditorStore((state) => state.globalTextStyle);
+	const textStyleScope = useMemeEditorStore((state) => state.textStyleScope);
+	const selectedTextboxId = useMemeEditorStore(
+		(state) => state.selectedTextboxId,
+	);
 	const addTextboxToStore = useMemeEditorStore((state) => state.addTextbox);
 	const addImageToStore = useMemeEditorStore((state) => state.addImage);
 	const resetEditor = useMemeEditorStore((state) => state.resetEditor);
@@ -397,6 +457,10 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 		}
 		return getPreviewScale(backgroundImage);
 	}, [backgroundImage]);
+	const disabledReason = getDeactivatedReason(
+		textStyleScope,
+		selectedTextboxId,
+	);
 
 	useEffect(() => {
 		const defaultFontSize = getDefaultFontSize(previewScale);
@@ -435,13 +499,16 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 					<div>
 						<TextStyleScopeInput />
 						<div className="grid">
-							<TextSizeInput previewScale={previewScale} />
-							<TextColorInput />
-							<TextAlignmentInput />
+							<TextSizeInput
+								previewScale={previewScale}
+								disabledReason={disabledReason}
+							/>
+							<TextColorInput disabledReason={disabledReason} />
+							<TextAlignmentInput disabledReason={disabledReason} />
 						</div>
 						<div className="grid">
-							<OutlineWidthInput />
-							<ShadowStrengthInput />
+							<OutlineWidthInput disabledReason={disabledReason} />
+							<ShadowStrengthInput disabledReason={disabledReason} />
 						</div>
 					</div>
 				</div>

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -17,8 +17,9 @@ import {
 type MemeEditorState = {
 	textboxes: Textbox[];
 	images: EditorImage[];
-	textStyle: TextStyle;
 	textStyleScope: TextStyleScope;
+	selectedTextboxId: string | null;
+	globalTextStyle: TextStyle;
 };
 
 type MemeEditorStore = MemeEditorState & {
@@ -28,58 +29,186 @@ type MemeEditorStore = MemeEditorState & {
 	setTextboxText: (id: string, text: string) => void;
 	setTextboxTransform: (id: string, transform: TextboxTransform) => void;
 	setImageTransform: (id: string, transform: ImageTransform) => void;
+	setTextStyleScope: (scope: TextStyleScope) => void;
+	setSelectedTextboxId: (id: string | null) => void;
 	setTextStyle: <K extends keyof TextStyle>(
 		field: K,
 		value: TextStyle[K],
 	) => void;
-	setTextStyleScope: (scope: TextStyleScope) => void;
+	getTextStyle: <K extends keyof TextStyle>(field: K) => TextStyle[K];
 };
 
 const applyTextboxTransform = (
-	textboxes: Textbox[],
+	state: MemeEditorState,
 	id: string,
 	transform: TextboxTransform,
-	textStyle: TextStyle,
 ) => {
+	const textboxes = state.textboxes;
+	const globalTextStyle = state.globalTextStyle;
+	const textStyleScope = state.textStyleScope;
+
 	if (transform.fontSize === undefined) {
 		return {
 			textboxes: updateTextbox(textboxes, id, transform),
-			textStyle,
+			globalTextStyle,
 		};
 	}
 
+	// update the textbox font size
 	const roundedFontSize = Math.round(transform.fontSize);
 	const nextTextboxes = updateTextbox(textboxes, id, {
 		...transform,
 		fontSize: roundedFontSize,
 	});
 
+	// if scope is global, update all textboxes to use the same font size
+	if (textStyleScope === "global") {
+		return applyGlobalTextStyleChange(
+			{
+				...state,
+				textboxes: nextTextboxes,
+			},
+			"fontSize",
+			roundedFontSize,
+		);
+	}
+
 	return {
-		textboxes: nextTextboxes.map((textbox) => ({
-			...textbox,
-			fontSize: roundedFontSize,
-		})),
-		textStyle: {
-			...textStyle,
-			fontSize: roundedFontSize,
-		},
+		textboxes: nextTextboxes,
+		globalTextStyle,
+	};
+};
+
+const toTextStyle = (textbox: Textbox): TextStyle => ({
+	fontSize: textbox.fontSize,
+	fill: textbox.fill,
+	textAlign: textbox.textAlign,
+	strokeWidth: textbox.strokeWidth,
+	shadowBlur: textbox.shadowBlur,
+});
+
+const getSelectedTextbox = (state: MemeEditorState) => {
+	if (!state.selectedTextboxId) {
+		return null;
+	}
+
+	const textbox = state.textboxes.find(
+		(textbox) => textbox.id === state.selectedTextboxId,
+	);
+	return textbox || null;
+};
+
+const getTextStyleValue = <K extends keyof TextStyle>(
+	state: MemeEditorState,
+	field: K,
+): TextStyle[K] => {
+	if (state.textStyleScope === "selected") {
+		const selectedTextbox = getSelectedTextbox(state);
+		if (selectedTextbox) {
+			return selectedTextbox[field];
+		}
+	}
+
+	return state.globalTextStyle[field];
+};
+
+const applyGlobalTextStyleChange = <K extends keyof TextStyle>(
+	state: MemeEditorState,
+	field: K,
+	value: TextStyle[K],
+): Pick<MemeEditorState, "textboxes" | "globalTextStyle"> => {
+	const textboxes = state.textboxes.map((textbox) => ({
+		...textbox,
+		[field]: value,
+	}));
+
+	const globalTextStyle = {
+		...state.globalTextStyle,
+		[field]: value,
+	};
+
+	return {
+		textboxes,
+		globalTextStyle,
+	};
+};
+
+const applyTextStyleChange = <K extends keyof TextStyle>(
+	state: MemeEditorState,
+	field: K,
+	value: TextStyle[K],
+) => {
+	let textboxes = state.textboxes;
+
+	// update all textboxes
+	if (state.textStyleScope === "global") {
+		return applyGlobalTextStyleChange(state, field, value);
+		// update just the selected textbox
+	} else if (state.selectedTextboxId) {
+		textboxes = updateTextbox(textboxes, state.selectedTextboxId, {
+			[field]: value,
+		});
+	}
+
+	return {
+		textboxes,
+	};
+};
+
+const applyTextStyleScopeChange = (
+	state: MemeEditorState,
+	newScope: TextStyleScope,
+) => {
+	// short-circuit if scope isn't changing
+	if (newScope === state.textStyleScope) {
+		return { textStyleScope: newScope };
+	}
+
+	// if switching scope to selected, reset global text style to default
+	if (newScope === "selected") {
+		const intialState = createInitialState();
+		return {
+			textStyleScope: newScope,
+			globalTextStyle: intialState.globalTextStyle,
+		};
+	}
+
+	// short-circuit if switching scope to global and no textboxes exist
+	if (state.textboxes.length === 0) {
+		return { textStyleScope: newScope };
+	}
+
+	// if switching scope to global, update all textboxes to use the same style as the first textbox
+	const firstTextbox = state.textboxes[0];
+	const nextTextStyle = toTextStyle(firstTextbox);
+	const textboxes = state.textboxes.map((textbox) => ({
+		...textbox,
+		...nextTextStyle,
+	}));
+
+	// update scope, set global text style to match the first textbox, and update all textboxes
+	return {
+		textStyleScope: newScope,
+		globalTextStyle: nextTextStyle,
+		textboxes,
 	};
 };
 
 const createInitialState = (): MemeEditorState => ({
 	textboxes: [],
 	images: [],
-	textStyle: {
+	textStyleScope: "global",
+	selectedTextboxId: null,
+	globalTextStyle: {
 		fontSize: DEFAULT_FONT_SIZE,
 		fill: DEFAULT_PRIMARY_TEXT_COLOR,
 		textAlign: DEFAULT_TEXT_ALIGNMENT,
 		strokeWidth: DEFAULT_STROKE_WIDTH,
 		shadowBlur: DEFAULT_SHADOW_BLUR,
 	},
-	textStyleScope: "all",
 });
 
-export const useMemeEditorStore = create<MemeEditorStore>((set) => ({
+export const useMemeEditorStore = create<MemeEditorStore>((set, get) => ({
 	...createInitialState(),
 	resetEditor: () => set(createInitialState()),
 	addTextbox: (textbox) =>
@@ -96,17 +225,7 @@ export const useMemeEditorStore = create<MemeEditorStore>((set) => ({
 		})),
 	setTextboxTransform: (id, transform) =>
 		set((state) => {
-			const result = applyTextboxTransform(
-				state.textboxes,
-				id,
-				transform,
-				state.textStyle,
-			);
-
-			return {
-				textboxes: result.textboxes,
-				textStyle: result.textStyle,
-			};
+			return applyTextboxTransform(state, id, transform);
 		}),
 	setImageTransform: (id, transform) =>
 		set((state) => ({
@@ -119,19 +238,13 @@ export const useMemeEditorStore = create<MemeEditorStore>((set) => ({
 					: image,
 			),
 		})),
-	setTextStyle: (field, value) =>
-		set((state) => ({
-			textStyle: {
-				...state.textStyle,
-				[field]: value,
-			},
-			textboxes: state.textboxes.map((textbox) => ({
-				...textbox,
-				[field]: value,
-			})),
-		})),
 	setTextStyleScope: (scope) =>
+		set((state) => applyTextStyleScopeChange(state, scope)),
+	setSelectedTextboxId: (id) =>
 		set(() => ({
-			textStyleScope: scope,
+			selectedTextboxId: id,
 		})),
+	setTextStyle: (field, value) =>
+		set((state) => applyTextStyleChange(state, field, value)),
+	getTextStyle: (field) => getTextStyleValue(get(), field),
 }));

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -204,7 +204,9 @@ const createDefaultTextStyle = (fontSize: number | null): TextStyle => ({
 	shadowBlur: DEFAULT_SHADOW_BLUR,
 });
 
-const createInitialState = (defaultFontSize: number | null = null): MemeEditorState => ({
+const createInitialState = (
+	defaultFontSize: number | null = null,
+): MemeEditorState => ({
 	textboxes: [],
 	images: [],
 	textStyleScope: "global",

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -19,6 +19,7 @@ type MemeEditorState = {
 	images: EditorImage[];
 	textStyleScope: TextStyleScope;
 	selectedTextboxId: string | null;
+	defaultFontSize: number | null;
 	globalTextStyle: TextStyle;
 };
 
@@ -31,6 +32,7 @@ type MemeEditorStore = MemeEditorState & {
 	setImageTransform: (id: string, transform: ImageTransform) => void;
 	setTextStyleScope: (scope: TextStyleScope) => void;
 	setSelectedTextboxId: (id: string | null) => void;
+	setDefaultFontSize: (fontSize: number) => void;
 	setTextStyle: <K extends keyof TextStyle>(
 		field: K,
 		value: TextStyle[K],
@@ -166,10 +168,10 @@ const applyTextStyleScopeChange = (
 
 	// if switching scope to selected, reset global text style to default
 	if (newScope === "selected") {
-		const intialState = createInitialState();
+		const defaultTextStyle = createDefaultTextStyle(state.defaultFontSize);
 		return {
 			textStyleScope: newScope,
-			globalTextStyle: intialState.globalTextStyle,
+			globalTextStyle: defaultTextStyle,
 		};
 	}
 
@@ -194,23 +196,29 @@ const applyTextStyleScopeChange = (
 	};
 };
 
-const createInitialState = (): MemeEditorState => ({
+const createDefaultTextStyle = (fontSize: number | null): TextStyle => ({
+	fontSize: fontSize ?? DEFAULT_FONT_SIZE,
+	fill: DEFAULT_PRIMARY_TEXT_COLOR,
+	textAlign: DEFAULT_TEXT_ALIGNMENT,
+	strokeWidth: DEFAULT_STROKE_WIDTH,
+	shadowBlur: DEFAULT_SHADOW_BLUR,
+});
+
+const createInitialState = (defaultFontSize: number | null = null): MemeEditorState => ({
 	textboxes: [],
 	images: [],
 	textStyleScope: "global",
 	selectedTextboxId: null,
-	globalTextStyle: {
-		fontSize: DEFAULT_FONT_SIZE,
-		fill: DEFAULT_PRIMARY_TEXT_COLOR,
-		textAlign: DEFAULT_TEXT_ALIGNMENT,
-		strokeWidth: DEFAULT_STROKE_WIDTH,
-		shadowBlur: DEFAULT_SHADOW_BLUR,
-	},
+	defaultFontSize,
+	globalTextStyle: createDefaultTextStyle(defaultFontSize),
 });
 
 export const useMemeEditorStore = create<MemeEditorStore>((set, get) => ({
 	...createInitialState(),
-	resetEditor: () => set(createInitialState()),
+	resetEditor: () =>
+		set((state) =>
+			createInitialState(state.defaultFontSize ?? DEFAULT_FONT_SIZE),
+		),
 	addTextbox: (textbox) =>
 		set((state) => ({
 			textboxes: [...state.textboxes, textbox],
@@ -243,6 +251,11 @@ export const useMemeEditorStore = create<MemeEditorStore>((set, get) => ({
 	setSelectedTextboxId: (id) =>
 		set(() => ({
 			selectedTextboxId: id,
+		})),
+	setDefaultFontSize: (fontSize) =>
+		set(() => ({
+			defaultFontSize: fontSize,
+			globalTextStyle: createDefaultTextStyle(fontSize),
 		})),
 	setTextStyle: (field, value) =>
 		set((state) => applyTextStyleChange(state, field, value)),

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -11,12 +11,14 @@ import {
 	type Textbox,
 	type TextboxTransform,
 	type TextStyle,
+	type TextStyleScope,
 } from "./types";
 
 type MemeEditorState = {
 	textboxes: Textbox[];
 	images: EditorImage[];
 	textStyle: TextStyle;
+	textStyleScope: TextStyleScope;
 };
 
 type MemeEditorStore = MemeEditorState & {
@@ -30,6 +32,7 @@ type MemeEditorStore = MemeEditorState & {
 		field: K,
 		value: TextStyle[K],
 	) => void;
+	setTextStyleScope: (scope: TextStyleScope) => void;
 };
 
 const applyTextboxTransform = (
@@ -73,6 +76,7 @@ const createInitialState = (): MemeEditorState => ({
 		strokeWidth: DEFAULT_STROKE_WIDTH,
 		shadowBlur: DEFAULT_SHADOW_BLUR,
 	},
+	textStyleScope: "all",
 });
 
 export const useMemeEditorStore = create<MemeEditorStore>((set) => ({
@@ -125,5 +129,9 @@ export const useMemeEditorStore = create<MemeEditorStore>((set) => ({
 				...textbox,
 				[field]: value,
 			})),
+		})),
+	setTextStyleScope: (scope) =>
+		set(() => ({
+			textStyleScope: scope,
 		})),
 }));

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -35,6 +35,7 @@ export type EditorNode = Point & {
 };
 
 export type TextAlignment = "center" | "left" | "right";
+export type TextStyleScope = "all" | "selected";
 
 export type TextStyle = {
 	fontSize: number;

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -34,8 +34,8 @@ export type EditorNode = Point & {
 	width: number;
 };
 
+export type TextStyleScope = "global" | "selected";
 export type TextAlignment = "center" | "left" | "right";
-export type TextStyleScope = "all" | "selected";
 
 export type TextStyle = {
 	fontSize: number;

--- a/frontend/src/components/Tooltip.module.css
+++ b/frontend/src/components/Tooltip.module.css
@@ -1,0 +1,3 @@
+.root[data-tooltip]:not(a, button, input) {
+	border-bottom: 0;
+}

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+import styles from "./Tooltip.module.css";
+
+export type TooltipProps = {
+	message: string;
+	active: boolean;
+	children: ReactNode;
+};
+
+export const Tooltip = ({ message, active, children }: TooltipProps) => {
+	const hasTooltip = active && message !== "";
+
+	if (!hasTooltip) {
+		return <>{children}</>;
+	}
+
+	return (
+		<div className={styles.root} data-tooltip={message} data-placement="top">
+			{children}
+		</div>
+	);
+};


### PR DESCRIPTION
Currently, all text styles are set globally. This is not ideal since you may want finer-grained control over specific textboxes.

I have added a new radio control to switch between applying styles to all textboxes and just the selected textbox (defaulted to all). The store now handles updating just one textbox if the scope is set to selected.

I validated that global scope still works and that selected scope works. I validated that when adding a new textbox, with global scope it inherits the same global styling. With selected scope, it inherits the default styling. I validated that when switching back to global scope all textboxes are updated (we just take the styling from a random textbox).

When the scope is selected but no textbox is selected, the inputs are greyed out and display a tooltip explaining why you cannot use the inputs.