### PR TITLE
minor: add button to delete selection

### DIFF
--- a/frontend/src/components/MemeEditor/Canvas.tsx
+++ b/frontend/src/components/MemeEditor/Canvas.tsx
@@ -5,7 +5,6 @@ import {
 	useEffect,
 	useImperativeHandle,
 	useRef,
-	useState,
 } from "react";
 import { Image as KonvaImage, Layer, Stage, Transformer } from "react-konva";
 import { useMemeEditorStore } from "./store";
@@ -157,11 +156,10 @@ export const Canvas = ({ backgroundImage, previewScale, ref }: CanvasProps) => {
 	const setImageTransform = useMemeEditorStore(
 		(state) => state.setImageTransform,
 	);
-	const setSelectedTextboxId = useMemeEditorStore(
-		(state) => state.setSelectedTextboxId,
+	const selectedNodeKey = useMemeEditorStore((state) => state.selectedNodeKey);
+	const setSelectedNodeKey = useMemeEditorStore(
+		(state) => state.setSelectedNodeKey,
 	);
-
-	const [selectedNodeKey, setSelectedNodeKey] = useState<NodeKey | null>(null);
 	const stageRef = useRef<Konva.Stage | null>(null);
 	const transformerRef = useRef<Konva.Transformer | null>(null);
 	const nodeRefs = useRef<Map<NodeKey, Konva.Node>>(new Map());
@@ -203,18 +201,7 @@ export const Canvas = ({ backgroundImage, previewScale, ref }: CanvasProps) => {
 
 	useEffect(() => {
 		clearStaleSelection(selectedNodeKey, textboxes, images, setSelectedNodeKey);
-	}, [selectedNodeKey, textboxes, images]);
-
-	useEffect(() => {
-		if (!selectedNodeKey) {
-			setSelectedTextboxId(null);
-			return;
-		}
-
-		const { keyType, id } = parseNodeKey(selectedNodeKey);
-		const selectedTextboxId = keyType === "text" ? id : null;
-		setSelectedTextboxId(selectedTextboxId);
-	}, [selectedNodeKey, setSelectedTextboxId]);
+	}, [selectedNodeKey, textboxes, images, setSelectedNodeKey]);
 
 	const textboxHandlers: TextboxHandlers = {
 		onEditTextbox: (id) => editTextbox({ textboxes, setTextboxText, id }),

--- a/frontend/src/components/MemeEditor/MemeEditor.module.css
+++ b/frontend/src/components/MemeEditor/MemeEditor.module.css
@@ -1,0 +1,16 @@
+.dangerButton:not(:disabled) {
+	background-color: #c62828;
+	border-color: #c62828;
+}
+
+.dangerButton:not(:disabled):hover,
+.dangerButton:not(:disabled):focus {
+	background-color: #b71c1c;
+	border-color: #b71c1c;
+}
+
+.dangerButton:disabled {
+	background-color: #c62828;
+	border-color: #c62828;
+	opacity: 0.5;
+}

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { Tooltip } from "../Tooltip";
 import { Canvas, type CanvasHandle } from "./Canvas";
+import styles from "./MemeEditor.module.css";
 import { useMemeEditorStore } from "./store";
 import {
 	createEditorImage,
@@ -16,9 +17,11 @@ import {
 	getCanvasMiddlePosition,
 	getDefaultFontSize,
 	getPreviewScale,
+	parseNodeKey,
 } from "./translation";
 import type {
 	BackgroundSource,
+	NodeKey,
 	TextAlignment,
 	TextStyle,
 	TextStyleScope,
@@ -40,15 +43,149 @@ const loadImage = (url: string) => {
 	});
 };
 
-const getDeactivatedReason = (
+const getTextInputDeactivatedReason = (
 	textStyleScope: TextStyleScope,
-	selectedTextboxId: string | null,
+	selectedNodeKey: NodeKey | null,
 ) => {
-	if (textStyleScope === "selected" && selectedTextboxId === null) {
+	if (textStyleScope !== "selected") {
+		return "";
+	}
+
+	if (selectedNodeKey == null) {
+		return "No textbox selected";
+	}
+
+	const { keyType } = parseNodeKey(selectedNodeKey);
+	if (keyType !== "text") {
 		return "No textbox selected";
 	}
 
 	return "";
+};
+
+const getDeleteButtonDeactivatedReason = (selectedNodeKey: NodeKey | null) => {
+	if (selectedNodeKey == null) {
+		return "No selection";
+	}
+
+	return "";
+};
+
+type AddImageButtonProps = {
+	backgroundImage: HTMLImageElement;
+	onAddImage: (image: ReturnType<typeof createEditorImage>) => void;
+};
+
+const AddImageButton = ({
+	backgroundImage,
+	onAddImage,
+}: AddImageButtonProps) => {
+	const imageUploadInputRef = useRef<HTMLInputElement | null>(null);
+
+	const openImageUpload = (event: MouseEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		const inputClicker = imageUploadInputRef.current;
+		if (!inputClicker) {
+			throw new Error("Image upload input ref is not set");
+		}
+
+		inputClicker.click();
+	};
+
+	const addImage = async (event: ChangeEvent<HTMLInputElement>) => {
+		const files = event.target.files;
+		if (!files || files.length === 0) {
+			return;
+		}
+
+		// reset input
+		event.target.value = "";
+
+		const imageFile = files[0];
+		const imageUrl = URL.createObjectURL(imageFile);
+		try {
+			const loadedImage = await loadImage(imageUrl);
+			const middlePosition = getCanvasMiddlePosition(backgroundImage);
+			onAddImage(createEditorImage(middlePosition, loadedImage));
+		} finally {
+			URL.revokeObjectURL(imageUrl);
+		}
+	};
+
+	return (
+		<>
+			<button type="button" onClick={openImageUpload}>
+				Add image
+			</button>
+			<input
+				ref={imageUploadInputRef}
+				type="file"
+				accept="image/*"
+				onChange={(event) => void addImage(event)}
+				hidden
+			/>
+		</>
+	);
+};
+
+type AddTextboxButtonProps = {
+	backgroundImage: HTMLImageElement;
+	textStyle: TextStyle;
+	onAddTextbox: (textbox: ReturnType<typeof createTextbox>) => void;
+};
+
+const AddTextboxButton = ({
+	backgroundImage,
+	textStyle,
+	onAddTextbox,
+}: AddTextboxButtonProps) => {
+	const addTextbox = (event: MouseEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		const middlePosition = getCanvasMiddlePosition(backgroundImage);
+		onAddTextbox(createTextbox(middlePosition, textStyle));
+	};
+
+	return (
+		<button type="button" onClick={addTextbox}>
+			Add textbox
+		</button>
+	);
+};
+
+const TextStyleScopeInput = () => {
+	const value = useMemeEditorStore((state) => state.textStyleScope);
+	const setTextStyleScope = useMemeEditorStore(
+		(state) => state.setTextStyleScope,
+	);
+
+	const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+		const nextScope = event.target.value as TextStyleScope;
+		setTextStyleScope(nextScope);
+	};
+
+	return (
+		<fieldset>
+			<legend>Apply text styles to</legend>
+			<input
+				type="radio"
+				id="text-style-scope-global"
+				name="text-style-scope"
+				value="global"
+				checked={value === "global"}
+				onChange={onChange}
+			/>
+			<label htmlFor="text-style-scope-global">All</label>
+			<input
+				type="radio"
+				id="text-style-scope-selected"
+				name="text-style-scope"
+				value="selected"
+				checked={value === "selected"}
+				onChange={onChange}
+			/>
+			<label htmlFor="text-style-scope-selected">Selected</label>
+		</fieldset>
+	);
 };
 
 type TextSizeInputProps = {
@@ -212,120 +349,36 @@ const ShadowStrengthInput = ({ disabledReason }: ShadowStrengthInputProps) => {
 	);
 };
 
-const TextStyleScopeInput = () => {
-	const value = useMemeEditorStore((state) => state.textStyleScope);
-	const setTextStyleScope = useMemeEditorStore(
-		(state) => state.setTextStyleScope,
+const DeleteSelectionButton = () => {
+	const selectedNodeKey = useMemeEditorStore((state) => state.selectedNodeKey);
+	const deleteSelectedNode = useMemeEditorStore(
+		(state) => state.deleteSelectedNode,
 	);
+	const disabled = selectedNodeKey === null;
 
-	const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-		const nextScope = event.target.value as TextStyleScope;
-		setTextStyleScope(nextScope);
-	};
+	return (
+		<Tooltip
+			message={getDeleteButtonDeactivatedReason(selectedNodeKey)}
+			active={disabled}
+		>
+				<button
+					type="button"
+					onClick={deleteSelectedNode}
+					disabled={disabled}
+					className={styles.dangerButton}
+				>
+					Delete Selection
+				</button>
+		</Tooltip>
+	);
+};
 
+const SelectionActions = () => {
 	return (
 		<fieldset>
-			<legend>Apply text styles to</legend>
-			<input
-				type="radio"
-				id="text-style-scope-global"
-				name="text-style-scope"
-				value="global"
-				checked={value === "global"}
-				onChange={onChange}
-			/>
-			<label htmlFor="text-style-scope-global">All</label>
-			<input
-				type="radio"
-				id="text-style-scope-selected"
-				name="text-style-scope"
-				value="selected"
-				checked={value === "selected"}
-				onChange={onChange}
-			/>
-			<label htmlFor="text-style-scope-selected">Selected</label>
+			<legend>Selection Actions</legend>
+			<DeleteSelectionButton />
 		</fieldset>
-	);
-};
-
-type AddImageButtonProps = {
-	backgroundImage: HTMLImageElement;
-	onAddImage: (image: ReturnType<typeof createEditorImage>) => void;
-};
-
-const AddImageButton = ({
-	backgroundImage,
-	onAddImage,
-}: AddImageButtonProps) => {
-	const imageUploadInputRef = useRef<HTMLInputElement | null>(null);
-
-	const openImageUpload = (event: MouseEvent<HTMLButtonElement>) => {
-		event.preventDefault();
-		const inputClicker = imageUploadInputRef.current;
-		if (!inputClicker) {
-			throw new Error("Image upload input ref is not set");
-		}
-
-		inputClicker.click();
-	};
-
-	const addImage = async (event: ChangeEvent<HTMLInputElement>) => {
-		const files = event.target.files;
-		if (!files || files.length === 0) {
-			return;
-		}
-
-		// reset input
-		event.target.value = "";
-
-		const imageFile = files[0];
-		const imageUrl = URL.createObjectURL(imageFile);
-		try {
-			const loadedImage = await loadImage(imageUrl);
-			const middlePosition = getCanvasMiddlePosition(backgroundImage);
-			onAddImage(createEditorImage(middlePosition, loadedImage));
-		} finally {
-			URL.revokeObjectURL(imageUrl);
-		}
-	};
-
-	return (
-		<>
-			<button type="button" onClick={openImageUpload}>
-				Add image
-			</button>
-			<input
-				ref={imageUploadInputRef}
-				type="file"
-				accept="image/*"
-				onChange={(event) => void addImage(event)}
-				hidden
-			/>
-		</>
-	);
-};
-
-type AddTextboxButtonProps = {
-	backgroundImage: HTMLImageElement;
-	textStyle: TextStyle;
-	onAddTextbox: (textbox: ReturnType<typeof createTextbox>) => void;
-};
-
-const AddTextboxButton = ({
-	backgroundImage,
-	textStyle,
-	onAddTextbox,
-}: AddTextboxButtonProps) => {
-	const addTextbox = (event: MouseEvent<HTMLButtonElement>) => {
-		event.preventDefault();
-		const middlePosition = getCanvasMiddlePosition(backgroundImage);
-		onAddTextbox(createTextbox(middlePosition, textStyle));
-	};
-
-	return (
-		<button type="button" onClick={addTextbox}>
-			Add textbox
-		</button>
 	);
 };
 
@@ -387,9 +440,7 @@ const CopyMemeButton = ({ getMemeBlob }: CopyMemeButtonProps) => {
 export const MemeEditor = ({ background }: MemeEditorProps) => {
 	const globalTextStyle = useMemeEditorStore((state) => state.globalTextStyle);
 	const textStyleScope = useMemeEditorStore((state) => state.textStyleScope);
-	const selectedTextboxId = useMemeEditorStore(
-		(state) => state.selectedTextboxId,
-	);
+	const selectedNodeKey = useMemeEditorStore((state) => state.selectedNodeKey);
 	const addTextboxToStore = useMemeEditorStore((state) => state.addTextbox);
 	const addImageToStore = useMemeEditorStore((state) => state.addImage);
 	const resetEditor = useMemeEditorStore((state) => state.resetEditor);
@@ -457,9 +508,9 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 		}
 		return getPreviewScale(backgroundImage);
 	}, [backgroundImage]);
-	const disabledReason = getDeactivatedReason(
+	const disabledReason = getTextInputDeactivatedReason(
 		textStyleScope,
-		selectedTextboxId,
+		selectedNodeKey,
 	);
 
 	useEffect(() => {
@@ -506,13 +557,14 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 							<TextColorInput disabledReason={disabledReason} />
 							<TextAlignmentInput disabledReason={disabledReason} />
 						</div>
-						<div className="grid">
-							<OutlineWidthInput disabledReason={disabledReason} />
-							<ShadowStrengthInput disabledReason={disabledReason} />
+							<div className="grid">
+								<OutlineWidthInput disabledReason={disabledReason} />
+								<ShadowStrengthInput disabledReason={disabledReason} />
+							</div>
+							<SelectionActions />
 						</div>
 					</div>
-				</div>
-			</form>
+				</form>
 			<div className="grid">
 				<DownloadMemeButton getMemeBlob={downloadBlob} />
 				<CopyMemeButton getMemeBlob={downloadBlob} />

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { parseNodeKey } from "./translation";
 import { updateTextbox } from "./translation";
 import {
 	DEFAULT_FONT_SIZE,
@@ -8,6 +9,7 @@ import {
 	DEFAULT_TEXT_ALIGNMENT,
 	type EditorImage,
 	type ImageTransform,
+	type NodeKey,
 	type Textbox,
 	type TextboxTransform,
 	type TextStyle,
@@ -18,7 +20,7 @@ type MemeEditorState = {
 	textboxes: Textbox[];
 	images: EditorImage[];
 	textStyleScope: TextStyleScope;
-	selectedTextboxId: string | null;
+	selectedNodeKey: NodeKey | null;
 	defaultFontSize: number | null;
 	globalTextStyle: TextStyle;
 };
@@ -31,7 +33,8 @@ type MemeEditorStore = MemeEditorState & {
 	setTextboxTransform: (id: string, transform: TextboxTransform) => void;
 	setImageTransform: (id: string, transform: ImageTransform) => void;
 	setTextStyleScope: (scope: TextStyleScope) => void;
-	setSelectedTextboxId: (id: string | null) => void;
+	setSelectedNodeKey: (nodeKey: NodeKey | null) => void;
+	deleteSelectedNode: () => void;
 	setDefaultFontSize: (fontSize: number) => void;
 	setTextStyle: <K extends keyof TextStyle>(
 		field: K,
@@ -90,13 +93,16 @@ const toTextStyle = (textbox: Textbox): TextStyle => ({
 });
 
 const getSelectedTextbox = (state: MemeEditorState) => {
-	if (!state.selectedTextboxId) {
+	if (!state.selectedNodeKey) {
 		return null;
 	}
 
-	const textbox = state.textboxes.find(
-		(textbox) => textbox.id === state.selectedTextboxId,
-	);
+	const { keyType, id } = parseNodeKey(state.selectedNodeKey);
+	if (keyType !== "text") {
+		return null;
+	}
+
+	const textbox = state.textboxes.find((item) => item.id === id);
 	return textbox || null;
 };
 
@@ -146,12 +152,16 @@ const applyTextStyleChange = <K extends keyof TextStyle>(
 	if (state.textStyleScope === "global") {
 		return applyGlobalTextStyleChange(state, field, value);
 		// update just the selected textbox
-	} else if (state.selectedTextboxId) {
-		textboxes = updateTextbox(textboxes, state.selectedTextboxId, {
+	} else if (state.selectedNodeKey !== null) {
+		const { keyType, id } = parseNodeKey(state.selectedNodeKey);
+		if (keyType !== "text") {
+			throw new Error("cannot set text style when non-textbox node is selected")
+		}
+
+		textboxes = updateTextbox(textboxes, id, {
 			[field]: value,
 		});
 	}
-
 	return {
 		textboxes,
 	};
@@ -196,6 +206,27 @@ const applyTextStyleScopeChange = (
 	};
 };
 
+const applySelectedNodeDeletion = (
+	state: MemeEditorState,
+): Partial<MemeEditorState> => {
+	if (!state.selectedNodeKey) {
+		return state;
+	}
+
+	const { keyType, id } = parseNodeKey(state.selectedNodeKey);
+	if (keyType === "text") {
+		return {
+			textboxes: state.textboxes.filter((textbox) => textbox.id !== id),
+			selectedNodeKey: null,
+		};
+	}
+
+	return {
+		images: state.images.filter((image) => image.id !== id),
+		selectedNodeKey: null,
+	};
+};
+
 const createDefaultTextStyle = (fontSize: number | null): TextStyle => ({
 	fontSize: fontSize ?? DEFAULT_FONT_SIZE,
 	fill: DEFAULT_PRIMARY_TEXT_COLOR,
@@ -210,7 +241,7 @@ const createInitialState = (
 	textboxes: [],
 	images: [],
 	textStyleScope: "global",
-	selectedTextboxId: null,
+	selectedNodeKey: null,
 	defaultFontSize,
 	globalTextStyle: createDefaultTextStyle(defaultFontSize),
 });
@@ -250,10 +281,11 @@ export const useMemeEditorStore = create<MemeEditorStore>((set, get) => ({
 		})),
 	setTextStyleScope: (scope) =>
 		set((state) => applyTextStyleScopeChange(state, scope)),
-	setSelectedTextboxId: (id) =>
+	setSelectedNodeKey: (nodeKey) =>
 		set(() => ({
-			selectedTextboxId: id,
+			selectedNodeKey: nodeKey,
 		})),
+	deleteSelectedNode: () => set((state) => applySelectedNodeDeletion(state)),
 	setDefaultFontSize: (fontSize) =>
 		set(() => ({
 			defaultFontSize: fontSize,


### PR DESCRIPTION
Currently there's no way to delete a textbox or image after you add it, you have to refresh the page and start over if you want to remove something.

I have added a new button to delete the selection. It works for both textboxes and images.