### PR TITLE
fix: default textbox width doesn't fit text

### DIFF
--- a/frontend/src/components/MemeEditor/translation.tsx
+++ b/frontend/src/components/MemeEditor/translation.tsx
@@ -22,7 +22,6 @@ import {
 	type TextStyle,
 } from "./types";
 
-const DEFAULT_TEXTBOX_WIDTH = 200;
 const MIN_TEXTBOX_WIDTH = 30;
 const MIN_FONT_SIZE = 8;
 const MIN_IMAGE_WIDTH = 20;
@@ -79,7 +78,7 @@ const onTransformTextboxEnd =
 			x: node.x(),
 			y: node.y(),
 			rotation: node.rotation(),
-			width: Math.max(MIN_TEXTBOX_WIDTH, textbox.width * scaleX),
+			width: Math.max(MIN_TEXTBOX_WIDTH, node.width() * scaleX),
 			fontSize: Math.round(Math.max(MIN_FONT_SIZE, textbox.fontSize * scaleY)),
 		});
 	};
@@ -119,7 +118,6 @@ export const createTextbox = (
 	x: initialPosition.x,
 	y: initialPosition.y,
 	rotation: DEFAULT_ROTATION,
-	width: DEFAULT_TEXTBOX_WIDTH,
 	fontSize: textStyle.fontSize,
 	fill: textStyle.fill,
 	textAlign: textStyle.textAlign,

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -31,7 +31,6 @@ export type Point = {
 export type EditorNode = Point & {
 	id: string;
 	rotation: number;
-	width: number;
 };
 
 export type TextStyleScope = "global" | "selected";
@@ -48,10 +47,12 @@ export type TextStyle = {
 export type Textbox = EditorNode &
 	TextStyle & {
 		text: string;
+		width?: number;
 	};
 
 export type EditorImage = EditorNode & {
 	image: HTMLImageElement;
+	width: number;
 	height: number;
 };
 
@@ -59,16 +60,17 @@ export type EditorNodeTransform = Partial<{
 	x: EditorNode["x"];
 	y: EditorNode["y"];
 	rotation: EditorNode["rotation"];
-	width: EditorNode["width"];
 }>;
 
 export type TextboxTransform = EditorNodeTransform &
 	Partial<{
 		fontSize: Textbox["fontSize"];
+		width: Textbox["width"];
 	}>;
 
 export type ImageTransform = EditorNodeTransform &
 	Partial<{
+		width: EditorImage["width"];
 		height: EditorImage["height"];
 	}>;
 


### PR DESCRIPTION
Currently we hardcode the default textbox width. The problem is that depending on the scale of the background, the initial contents of the textbox may not fit within the width of the textbox.

I have changed the logic to autosize the textbox when initially created, so now the default text will always fit.