### PR TITLE
fix: image upload doesn't work in Chrome

### DIFF
--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -98,11 +98,12 @@ const AddImageButton = ({
 			return;
 		}
 
+		const imageFile = files[0];
+		const imageUrl = URL.createObjectURL(imageFile);
+
 		// reset input
 		event.target.value = "";
 
-		const imageFile = files[0];
-		const imageUrl = URL.createObjectURL(imageFile);
 		try {
 			const loadedImage = await loadImage(imageUrl);
 			const middlePosition = getCanvasMiddlePosition(backgroundImage);


### PR DESCRIPTION
I noticed the following error in the browser console in Chrome when I tried to upload an image:
```
index-CCVRApTT.js:43 Uncaught (in promise) TypeError: Failed to execute 'createObjectURL' on 'URL': Overload resolution failed.
    at f (index-CCVRApTT.js:43:15511)
    at onChange (index-CCVRApTT.js:43:15768)
    at y2 (index-CCVRApTT.js:8:127821)
    at index-CCVRApTT.js:8:133000
    at Mo (index-CCVRApTT.js:8:15137)
    at t1 (index-CCVRApTT.js:8:129057)
    at m1 (index-CCVRApTT.js:9:28628)
    at Q3 (index-CCVRApTT.js:9:28446)

```
interestingly the image upload worked fine in Firefox.

The issue was that the input was getting cleared before we got the actual file. I have fixed this by waiting to clear the input until after we've gotten the file and created the image URL.

I have validated that image upload now works in both Chrome and Firefox.