### PR TITLE
minor: add all caps input

### DIFF
--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -350,6 +350,30 @@ const ShadowStrengthInput = ({ disabledReason }: ShadowStrengthInputProps) => {
 	);
 };
 
+type CapsInputProps = {
+	disabledReason: string;
+};
+
+const CapsInput = ({ disabledReason }: CapsInputProps) => {
+	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const value = useMemeEditorStore((state) => state.getTextStyle("caps"));
+	const disabled = disabledReason !== "";
+
+	return (
+		<Tooltip message={disabledReason} active={disabled}>
+			<label>
+				<input
+					type="checkbox"
+					checked={value}
+					onChange={(event) => setTextStyle("caps", event.target.checked)}
+					disabled={disabled}
+				/>
+				CAPS
+			</label>
+		</Tooltip>
+	);
+};
+
 const DeleteSelectionButton = () => {
 	const selectedNodeKey = useMemeEditorStore((state) => state.selectedNodeKey);
 	const deleteSelectedNode = useMemeEditorStore(
@@ -561,6 +585,9 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 						<div className="grid">
 							<OutlineWidthInput disabledReason={disabledReason} />
 							<ShadowStrengthInput disabledReason={disabledReason} />
+						</div>
+						<div className="grid">
+							<CapsInput disabledReason={disabledReason} />
 						</div>
 						<SelectionActions />
 					</div>

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -89,6 +89,7 @@ const toTextStyle = (textbox: Textbox): TextStyle => ({
 	textAlign: textbox.textAlign,
 	strokeWidth: textbox.strokeWidth,
 	shadowBlur: textbox.shadowBlur,
+	caps: textbox.caps,
 });
 
 const getSelectedTextbox = (state: MemeEditorState) => {
@@ -234,6 +235,7 @@ const createDefaultTextStyle = (fontSize: number | null): TextStyle => ({
 	textAlign: DEFAULT_TEXT_ALIGNMENT,
 	strokeWidth: DEFAULT_STROKE_WIDTH,
 	shadowBlur: DEFAULT_SHADOW_BLUR,
+	caps: true,
 });
 
 const createInitialState = (

--- a/frontend/src/components/MemeEditor/translation.tsx
+++ b/frontend/src/components/MemeEditor/translation.tsx
@@ -102,6 +102,10 @@ const onTransformImageEnd =
 		});
 	};
 
+const getTextboxDisplayText = (textbox: Textbox) => {
+	return textbox.caps ? textbox.text.toUpperCase() : textbox.text;
+};
+
 export const getCanvasMiddlePosition = (
 	backgroundImage: HTMLImageElement,
 ): Point => ({
@@ -123,6 +127,7 @@ export const createTextbox = (
 	textAlign: textStyle.textAlign,
 	strokeWidth: textStyle.strokeWidth,
 	shadowBlur: textStyle.shadowBlur,
+	caps: textStyle.caps,
 });
 
 export const createEditorImage = (
@@ -154,7 +159,7 @@ export const textboxesToKonvaText = (
 			y={textbox.y}
 			rotation={textbox.rotation}
 			width={textbox.width}
-			text={textbox.text}
+			text={getTextboxDisplayText(textbox)}
 			fontFamily={DEFAULT_FONT_FAMILY}
 			fontSize={textbox.fontSize}
 			fill={textbox.fill}

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -42,6 +42,7 @@ export type TextStyle = {
 	textAlign: TextAlignment;
 	strokeWidth: number;
 	shadowBlur: number;
+	caps: boolean;
 };
 
 export type Textbox = EditorNode &


### PR DESCRIPTION
Most memes are written in all caps. This should be enabled by default, but provide the option to disable.

I have added a new checkbox for all caps. I have tested that it works for all textboxes when the all scope is selected, and individual textboxes when the selected scope is selected.