### PR TITLE
chore: remove form

### DIFF
--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -26,7 +26,14 @@ import type {
 	TextStyle,
 	TextStyleScope,
 } from "./types";
-import { IMAGE_MIME_TYPE } from "./types";
+import {
+	IMAGE_MIME_TYPE,
+	MAX_SHADOW_BLUR,
+	MAX_STROKE_WIDTH,
+	MIN_FONT_SIZE,
+	MIN_SHADOW_BLUR,
+	MIN_STROKE_WIDTH,
+} from "./types";
 
 export type MemeEditorProps = {
 	background: BackgroundSource;
@@ -200,6 +207,7 @@ const TextSizeInput = ({
 }: TextSizeInputProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
 	const value = useMemeEditorStore((state) => state.getTextStyle("fontSize"));
+	const minDisplayValue = Math.max(1, Math.ceil(MIN_FONT_SIZE * previewScale));
 	const displayValue = Math.max(1, Math.round(value * previewScale));
 	const disabled = disabledReason !== "";
 
@@ -208,12 +216,12 @@ const TextSizeInput = ({
 		const inputSize = Math.round(Number(event.target.value));
 		const isValidNumber = Number.isFinite(inputSize) && inputSize > 0;
 
-		// clamp display size to 1 if input is invalid
-		const clampedDisplaySize = isValidNumber ? inputSize : 1;
+		// clamp display size to min text size if input is invalid
+		const clampedDisplaySize = isValidNumber ? inputSize : minDisplayValue;
 
 		// convert display size to actual size
 		const actualSize = Math.max(
-			1,
+			MIN_FONT_SIZE,
 			Math.round(clampedDisplaySize / previewScale),
 		);
 
@@ -223,13 +231,16 @@ const TextSizeInput = ({
 	return (
 		<Tooltip message={disabledReason} active={disabled}>
 			<label>
-				Text size
-				<input
-					type="number"
-					value={displayValue}
-					onChange={handleChange}
-					disabled={disabled}
-				/>
+					Text size
+					<input
+						type="number"
+						inputMode="numeric"
+						min={minDisplayValue}
+						step={1}
+						value={displayValue}
+						onChange={handleChange}
+						disabled={disabled}
+					/>
 			</label>
 		</Tooltip>
 	);
@@ -303,16 +314,16 @@ const OutlineWidthInput = ({ disabledReason }: OutlineWidthInputProps) => {
 
 	return (
 		<Tooltip message={disabledReason} active={disabled}>
-			<label>
-				Outline width: {value}
-				<input
-					type="range"
-					min="0.5"
-					max="10"
-					step="0.5"
-					value={value}
-					onChange={(event) =>
-						setTextStyle("strokeWidth", Number(event.target.value))
+				<label>
+					Outline width: {value}
+					<input
+						type="range"
+						min={MIN_STROKE_WIDTH}
+						max={MAX_STROKE_WIDTH}
+						step="0.5"
+						value={value}
+						onChange={(event) =>
+							setTextStyle("strokeWidth", Number(event.target.value))
 					}
 					disabled={disabled}
 				/>
@@ -332,16 +343,16 @@ const ShadowStrengthInput = ({ disabledReason }: ShadowStrengthInputProps) => {
 
 	return (
 		<Tooltip message={disabledReason} active={disabled}>
-			<label>
-				Shadow strength: {value}
-				<input
-					type="range"
-					min="0"
-					max="50"
-					step="1"
-					value={value}
-					onChange={(event) =>
-						setTextStyle("shadowBlur", Number(event.target.value))
+				<label>
+					Shadow strength: {value}
+					<input
+						type="range"
+						min={MIN_SHADOW_BLUR}
+						max={MAX_SHADOW_BLUR}
+						step="1"
+						value={value}
+						onChange={(event) =>
+							setTextStyle("shadowBlur", Number(event.target.value))
 					}
 					disabled={disabled}
 				/>
@@ -549,31 +560,32 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 
 	return (
 		<>
-			<form>
+			<div className="grid">
 				<div className="grid">
-					<div className="grid">
-						<AddImageButton
-							backgroundImage={backgroundImage}
-							onAddImage={addImageToStore}
-						/>
-						<AddTextboxButton
-							backgroundImage={backgroundImage}
-							textStyle={globalTextStyle}
-							onAddTextbox={addTextboxToStore}
-						/>
-					</div>
-					<div></div>
+					<AddImageButton
+						backgroundImage={backgroundImage}
+						onAddImage={addImageToStore}
+					/>
+					<AddTextboxButton
+						backgroundImage={backgroundImage}
+						textStyle={globalTextStyle}
+						onAddTextbox={addTextboxToStore}
+					/>
 				</div>
-				<div className="grid">
-					<div>
-						<Canvas
-							ref={canvasRef}
-							backgroundImage={backgroundImage}
-							previewScale={previewScale}
-						/>
-					</div>
-					<div>
-						<TextStyleScopeInput />
+				<div></div>
+			</div>
+			<div className="grid">
+				<div>
+					<Canvas
+						ref={canvasRef}
+						backgroundImage={backgroundImage}
+						previewScale={previewScale}
+					/>
+				</div>
+				<div>
+					<TextStyleScopeInput />
+					<fieldset>
+						<legend>Text Style</legend>
 						<div className="grid">
 							<TextSizeInput
 								previewScale={previewScale}
@@ -589,10 +601,10 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 						<div className="grid">
 							<CapsInput disabledReason={disabledReason} />
 						</div>
-						<SelectionActions />
-					</div>
+					</fieldset>
+					<SelectionActions />
 				</div>
-			</form>
+			</div>
 			<div className="grid">
 				<DownloadMemeButton getMemeBlob={downloadBlob} />
 				<CopyMemeButton getMemeBlob={downloadBlob} />

--- a/frontend/src/components/MemeEditor/translation.tsx
+++ b/frontend/src/components/MemeEditor/translation.tsx
@@ -8,6 +8,7 @@ import {
 	DEFAULT_ROTATION,
 	DEFAULT_SECONDARY_TEXT_COLOR,
 	DEFAULT_TEXT,
+	MIN_FONT_SIZE,
 	DEFAULT_X_OFFSET,
 	DEFAULT_Y_OFFSET,
 	EDITOR_PREVIEW_MAX_HEIGHT,
@@ -23,7 +24,6 @@ import {
 } from "./types";
 
 const MIN_TEXTBOX_WIDTH = 30;
-const MIN_FONT_SIZE = 8;
 const MIN_IMAGE_WIDTH = 20;
 const MIN_IMAGE_HEIGHT = 20;
 const DEFAULT_IMAGE_SCALE = 0.25;
@@ -35,7 +35,10 @@ export const getPreviewScale = (backgroundImage: HTMLImageElement) => {
 };
 
 export const getDefaultFontSize = (previewScale: number) => {
-	return Math.max(1, Math.round(DEFAULT_DISPLAY_FONT_SIZE / previewScale));
+	return Math.max(
+		MIN_FONT_SIZE,
+		Math.round(DEFAULT_DISPLAY_FONT_SIZE / previewScale),
+	);
 };
 
 export const createNodeKey = (keyType: KeyType, id: string): NodeKey =>

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -10,9 +10,14 @@ export const DEFAULT_ROTATION = 0;
 export const DEFAULT_TEXT_ALIGNMENT: TextAlignment = "center";
 export const DEFAULT_FONT_FAMILY = "Impact";
 export const DEFAULT_FONT_SIZE = 50;
+export const MIN_FONT_SIZE = 8;
+export const MIN_STROKE_WIDTH = 0;
+export const MAX_STROKE_WIDTH = 10;
 export const DEFAULT_STROKE_WIDTH = 3;
 export const DEFAULT_PRIMARY_TEXT_COLOR = "#FFFFFF";
 export const DEFAULT_SECONDARY_TEXT_COLOR = "#000000";
+export const MIN_SHADOW_BLUR = 0;
+export const MAX_SHADOW_BLUR = 50;
 export const DEFAULT_SHADOW_BLUR = 30;
 export const IMAGE_MIME_TYPE = "image/png";
 

--- a/frontend/src/components/Tooltip.module.css
+++ b/frontend/src/components/Tooltip.module.css
@@ -1,3 +1,6 @@
 .root[data-tooltip]:not(a, button, input) {
+	display: inline-block;
+	width: fit-content;
 	border-bottom: 0;
+	cursor: default;
 }

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -9,13 +9,12 @@ export type TooltipProps = {
 
 export const Tooltip = ({ message, active, children }: TooltipProps) => {
 	const hasTooltip = active && message !== "";
-
-	if (!hasTooltip) {
-		return <>{children}</>;
-	}
-
 	return (
-		<div className={styles.root} data-tooltip={message} data-placement="top">
+		<div
+			className={styles.root}
+			data-tooltip={hasTooltip ? message : undefined}
+			data-placement={"top"}
+		>
 			{children}
 		</div>
 	);


### PR DESCRIPTION
The input panel for the meme maker canvas does not need to be a form since it has no submission. It is more idiomatic to not use a form.

Made some minor tweaks:
- Removed form element
- Added consts for min/max sizes
- Set the text size input to use an input mode so browsers have an additional hint about the expected content
- Added a text style legend to a new text styles fieldset
- Fixed the tooltip above the CAPS checkbox showing up in the middle of the panel instead of above the checkbox
- Removed the question mark cursor when tooltip is displayed, as it showed up inconsistently based on whether a label element was blocking the tooltip