### PR TITLE
minor: add additional text properties

### DIFF
--- a/frontend/src/components/MemeEditor/MemeEditor.module.css
+++ b/frontend/src/components/MemeEditor/MemeEditor.module.css
@@ -14,3 +14,19 @@
 	border-color: #c62828;
 	opacity: 0.5;
 }
+
+.boldLabel {
+	font-weight: bold;
+}
+
+.italicLabel {
+	font-style: italic;
+}
+
+.underlineLabel {
+	text-decoration: underline;
+}
+
+.strikethroughLabel {
+	text-decoration: line-through;
+}

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -361,13 +361,21 @@ const ShadowStrengthInput = ({ disabledReason }: ShadowStrengthInputProps) => {
 	);
 };
 
-type CapsInputProps = {
+type TextPropertyCheckboxProps = {
+	field: "caps" | "bold" | "italic" | "underline" | "strikethrough";
+	label: string;
+	labelClassName: string;
 	disabledReason: string;
 };
 
-const CapsInput = ({ disabledReason }: CapsInputProps) => {
+const TextPropertyCheckbox = ({
+	disabledReason,
+	field,
+	label,
+	labelClassName,
+}: TextPropertyCheckboxProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
-	const value = useMemeEditorStore((state) => state.getTextStyle("caps"));
+	const value = useMemeEditorStore((state) => state.getTextStyle(field));
 	const disabled = disabledReason !== "";
 
 	return (
@@ -376,10 +384,10 @@ const CapsInput = ({ disabledReason }: CapsInputProps) => {
 				<input
 					type="checkbox"
 					checked={value}
-					onChange={(event) => setTextStyle("caps", event.target.checked)}
+					onChange={(event) => setTextStyle(field, event.target.checked)}
 					disabled={disabled}
 				/>
-				CAPS
+				<span className={labelClassName}>{label}</span>
 			</label>
 		</Tooltip>
 	);
@@ -585,7 +593,7 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 				<div>
 					<TextStyleScopeInput />
 					<fieldset>
-						<legend>Text Style</legend>
+						<legend>Text Styles</legend>
 						<div className="grid">
 							<TextSizeInput
 								previewScale={previewScale}
@@ -595,11 +603,42 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 							<TextAlignmentInput disabledReason={disabledReason} />
 						</div>
 						<div className="grid">
-							<OutlineWidthInput disabledReason={disabledReason} />
-							<ShadowStrengthInput disabledReason={disabledReason} />
-						</div>
-						<div className="grid">
-							<CapsInput disabledReason={disabledReason} />
+							<div>
+								<TextPropertyCheckbox
+									disabledReason={disabledReason}
+									field="caps"
+									label="CAPS"
+									labelClassName=""
+								/>
+								<TextPropertyCheckbox
+									disabledReason={disabledReason}
+									field="bold"
+									label="Bold"
+									labelClassName={styles.boldLabel}
+								/>
+								<TextPropertyCheckbox
+									disabledReason={disabledReason}
+									field="italic"
+									label="Italic"
+									labelClassName={styles.italicLabel}
+								/>
+								<TextPropertyCheckbox
+									disabledReason={disabledReason}
+									field="underline"
+									label="Underline"
+									labelClassName={styles.underlineLabel}
+								/>
+								<TextPropertyCheckbox
+									disabledReason={disabledReason}
+									field="strikethrough"
+									label="Strikethrough"
+									labelClassName={styles.strikethroughLabel}
+								/>
+							</div>
+							<div>
+								<OutlineWidthInput disabledReason={disabledReason} />
+								<ShadowStrengthInput disabledReason={disabledReason} />
+							</div>
 						</div>
 					</fieldset>
 					<SelectionActions />

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -90,6 +90,10 @@ const toTextStyle = (textbox: Textbox): TextStyle => ({
 	strokeWidth: textbox.strokeWidth,
 	shadowBlur: textbox.shadowBlur,
 	caps: textbox.caps,
+	bold: textbox.bold,
+	italic: textbox.italic,
+	underline: textbox.underline,
+	strikethrough: textbox.strikethrough,
 });
 
 const getSelectedTextbox = (state: MemeEditorState) => {
@@ -236,6 +240,10 @@ const createDefaultTextStyle = (fontSize: number | null): TextStyle => ({
 	strokeWidth: DEFAULT_STROKE_WIDTH,
 	shadowBlur: DEFAULT_SHADOW_BLUR,
 	caps: true,
+	bold: false,
+	italic: false,
+	underline: false,
+	strikethrough: false,
 });
 
 const createInitialState = (

--- a/frontend/src/components/MemeEditor/translation.tsx
+++ b/frontend/src/components/MemeEditor/translation.tsx
@@ -109,6 +109,34 @@ const getTextboxDisplayText = (textbox: Textbox) => {
 	return textbox.caps ? textbox.text.toUpperCase() : textbox.text;
 };
 
+const getTextboxFontStyle = (textbox: Textbox) => {
+	const fontStyles = [];
+
+	if (textbox.bold) {
+		fontStyles.push("bold");
+	}
+
+	if (textbox.italic) {
+		fontStyles.push("italic");
+	}
+
+	return fontStyles.join(" ");
+};
+
+const getTextboxTextDecoration = (textbox: Textbox) => {
+	const decorations = [];
+
+	if (textbox.underline) {
+		decorations.push("underline");
+	}
+
+	if (textbox.strikethrough) {
+		decorations.push("line-through");
+	}
+
+	return decorations.join(" ");
+};
+
 export const getCanvasMiddlePosition = (
 	backgroundImage: HTMLImageElement,
 ): Point => ({
@@ -131,6 +159,10 @@ export const createTextbox = (
 	strokeWidth: textStyle.strokeWidth,
 	shadowBlur: textStyle.shadowBlur,
 	caps: textStyle.caps,
+	bold: textStyle.bold,
+	italic: textStyle.italic,
+	underline: textStyle.underline,
+	strikethrough: textStyle.strikethrough,
 });
 
 export const createEditorImage = (
@@ -165,8 +197,10 @@ export const textboxesToKonvaText = (
 			text={getTextboxDisplayText(textbox)}
 			fontFamily={DEFAULT_FONT_FAMILY}
 			fontSize={textbox.fontSize}
+			fontStyle={getTextboxFontStyle(textbox)}
 			fill={textbox.fill}
 			align={textbox.textAlign}
+			textDecoration={getTextboxTextDecoration(textbox)}
 			stroke={DEFAULT_SECONDARY_TEXT_COLOR}
 			strokeWidth={textbox.strokeWidth}
 			shadowColor={DEFAULT_SECONDARY_TEXT_COLOR}

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -48,6 +48,10 @@ export type TextStyle = {
 	strokeWidth: number;
 	shadowBlur: number;
 	caps: boolean;
+	bold: boolean;
+	italic: boolean;
+	underline: boolean;
+	strikethrough: boolean;
 };
 
 export type Textbox = EditorNode &


### PR DESCRIPTION
We should support more ways to style text, such as bold, italic, underline, and strikethrough.

Added new checkboxes for each of these styles.

I validated that various combinations of new styles work together.