### PR TITLE
fix: tooltip causing inputs to move around

### DIFF
--- a/frontend/src/components/MemeEditor/MemeEditor.module.css
+++ b/frontend/src/components/MemeEditor/MemeEditor.module.css
@@ -1,3 +1,7 @@
+.dangerButton {
+	width: auto;
+}
+
 .dangerButton:not(:disabled) {
 	background-color: #c62828;
 	border-color: #c62828;

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -379,7 +379,7 @@ const TextPropertyCheckbox = ({
 	const disabled = disabledReason !== "";
 
 	return (
-		<Tooltip message={disabledReason} active={disabled}>
+		<Tooltip message={disabledReason} active={disabled} placement="left">
 			<label>
 				<input
 					type="checkbox"
@@ -404,6 +404,7 @@ const DeleteSelectionButton = () => {
 		<Tooltip
 			message={getDeleteButtonDeactivatedReason(selectedNodeKey)}
 			active={disabled}
+			inline
 		>
 			<button
 				type="button"

--- a/frontend/src/components/Tooltip.module.css
+++ b/frontend/src/components/Tooltip.module.css
@@ -1,6 +1,9 @@
 .root[data-tooltip]:not(a, button, input) {
-	display: inline-block;
-	width: fit-content;
 	border-bottom: 0;
 	cursor: default;
+}
+
+.inline {
+	display: inline-block;
+	width: fit-content;
 }

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -5,15 +5,24 @@ export type TooltipProps = {
 	message: string;
 	active: boolean;
 	children: ReactNode;
+	inline?: boolean;
+	placement?: "top" | "left";
 };
 
-export const Tooltip = ({ message, active, children }: TooltipProps) => {
+export const Tooltip = ({
+	message,
+	active,
+	children,
+	inline = false,
+	placement = "top",
+}: TooltipProps) => {
 	const hasTooltip = active && message !== "";
+	const className = inline ? `${styles.root} ${styles.inline}` : styles.root;
 	return (
 		<div
-			className={styles.root}
+			className={className}
 			data-tooltip={hasTooltip ? message : undefined}
-			data-placement={"top"}
+			data-placement={placement}
 		>
 			{children}
 		</div>


### PR DESCRIPTION
There is a bug with the tooltip where it is causing inputs to move around and change sizes.

The cause is because the page layout changes when the tooltip becomes active because of the CSS `display` property. This has been fixed by adding an optional `inline` prop to the tooltip so it can know when to use that `display` property.

I also updated the delete button to have width `auto` so it doesn't attempt to fill the width anymore, and I added an optional `placement` prop to the Tooltip because the checkboxes looked odd with a top tooltip (it was displaying in the middle, even if the text label wasn't that long).