### PR TITLE
minor: snap when rotating text and images

### DIFF
--- a/frontend/src/components/MemeEditor/Canvas.tsx
+++ b/frontend/src/components/MemeEditor/Canvas.tsx
@@ -245,7 +245,13 @@ export const Canvas = ({ backgroundImage, previewScale, ref }: CanvasProps) => {
 				/>
 				{konvaImages}
 				{konvaText}
-				<Transformer ref={transformerRef} rotateEnabled resizeEnabled />
+				<Transformer
+					ref={transformerRef}
+					rotateEnabled
+					resizeEnabled
+					rotationSnaps={[0, 90, 180, 270]}
+					rotationSnapTolerance={8}
+				/>
 			</Layer>
 		</Stage>
 	);


### PR DESCRIPTION
Currently when rotating, there are no snap points. This means it's hard to get the rotation perfect.

I have added snap points every 90 degrees with a tolerance of 8.