### PR TITLE
minor: add dropdown for fonts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Archivo+Black&family=Arimo:ital,wght@0,400;0,700;1,400;1,700&family=Bangers&family=Bebas+Neue&family=Comic+Neue:ital,wght@0,400;0,700;1,400;1,700&family=Luckiest+Guy&family=Montserrat:ital,wght@0,400;0,700;1,400;1,700&family=Noto+Sans&family=Oswald:wght@400;700&display=swap"
       rel="stylesheet"
     />
     <link

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -30,6 +30,7 @@ import {
 	IMAGE_MIME_TYPE,
 	MAX_SHADOW_BLUR,
 	MAX_STROKE_WIDTH,
+	MEME_FONTS,
 	MIN_FONT_SIZE,
 	MIN_SHADOW_BLUR,
 	MIN_STROKE_WIDTH,
@@ -231,16 +232,52 @@ const TextSizeInput = ({
 	return (
 		<Tooltip message={disabledReason} active={disabled}>
 			<label>
-					Text size
-					<input
-						type="number"
-						inputMode="numeric"
-						min={minDisplayValue}
-						step={1}
-						value={displayValue}
-						onChange={handleChange}
-						disabled={disabled}
-					/>
+				Text size
+				<input
+					type="number"
+					inputMode="numeric"
+					min={minDisplayValue}
+					step={1}
+					value={displayValue}
+					onChange={handleChange}
+					disabled={disabled}
+				/>
+			</label>
+		</Tooltip>
+	);
+};
+
+type FontFamilyInputProps = {
+	disabledReason: string;
+};
+
+const FontFamilyInput = ({ disabledReason }: FontFamilyInputProps) => {
+	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
+	const value = useMemeEditorStore((state) => state.getTextStyle("fontFamily"));
+	const disabled = disabledReason !== "";
+
+	const options = useMemo(() => {
+		const fontFamilies = MEME_FONTS.map((font) => {
+			return (
+				<option value={font.fontFamily} key={font.label}>
+					{font.label}
+				</option>
+			);
+		});
+		return fontFamilies;
+	}, []);
+
+	return (
+		<Tooltip message={disabledReason} active={disabled}>
+			<label>
+				Font
+				<select
+					value={value}
+					onChange={(event) => setTextStyle("fontFamily", event.target.value)}
+					disabled={disabled}
+				>
+					{options}
+				</select>
 			</label>
 		</Tooltip>
 	);
@@ -314,16 +351,16 @@ const OutlineWidthInput = ({ disabledReason }: OutlineWidthInputProps) => {
 
 	return (
 		<Tooltip message={disabledReason} active={disabled}>
-				<label>
-					Outline width: {value}
-					<input
-						type="range"
-						min={MIN_STROKE_WIDTH}
-						max={MAX_STROKE_WIDTH}
-						step="0.5"
-						value={value}
-						onChange={(event) =>
-							setTextStyle("strokeWidth", Number(event.target.value))
+			<label>
+				Outline width: {value}
+				<input
+					type="range"
+					min={MIN_STROKE_WIDTH}
+					max={MAX_STROKE_WIDTH}
+					step="0.5"
+					value={value}
+					onChange={(event) =>
+						setTextStyle("strokeWidth", Number(event.target.value))
 					}
 					disabled={disabled}
 				/>
@@ -343,16 +380,16 @@ const ShadowStrengthInput = ({ disabledReason }: ShadowStrengthInputProps) => {
 
 	return (
 		<Tooltip message={disabledReason} active={disabled}>
-				<label>
-					Shadow strength: {value}
-					<input
-						type="range"
-						min={MIN_SHADOW_BLUR}
-						max={MAX_SHADOW_BLUR}
-						step="1"
-						value={value}
-						onChange={(event) =>
-							setTextStyle("shadowBlur", Number(event.target.value))
+			<label>
+				Shadow strength: {value}
+				<input
+					type="range"
+					min={MIN_SHADOW_BLUR}
+					max={MAX_SHADOW_BLUR}
+					step="1"
+					value={value}
+					onChange={(event) =>
+						setTextStyle("shadowBlur", Number(event.target.value))
 					}
 					disabled={disabled}
 				/>
@@ -501,6 +538,7 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 		if (!canvas) {
 			throw new Error("Canvas export is not ready");
 		}
+		await document.fonts.ready;
 		return canvas.exportBlob();
 	}, []);
 
@@ -596,10 +634,13 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 					<fieldset>
 						<legend>Text Styles</legend>
 						<div className="grid">
+							<FontFamilyInput disabledReason={disabledReason} />
 							<TextSizeInput
 								previewScale={previewScale}
 								disabledReason={disabledReason}
 							/>
+						</div>
+						<div className="grid">
 							<TextColorInput disabledReason={disabledReason} />
 							<TextAlignmentInput disabledReason={disabledReason} />
 						</div>

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { parseNodeKey, updateTextbox } from "./translation";
 import {
 	DEFAULT_FONT_SIZE,
+	DEFAULT_MEME_FONT,
 	DEFAULT_PRIMARY_TEXT_COLOR,
 	DEFAULT_SHADOW_BLUR,
 	DEFAULT_STROKE_WIDTH,
@@ -84,6 +85,7 @@ const applyTextboxTransform = (
 };
 
 const toTextStyle = (textbox: Textbox): TextStyle => ({
+	fontFamily: textbox.fontFamily,
 	fontSize: textbox.fontSize,
 	fill: textbox.fill,
 	textAlign: textbox.textAlign,
@@ -234,6 +236,7 @@ const applySelectedNodeDeletion = (
 };
 
 const createDefaultTextStyle = (fontSize: number | null): TextStyle => ({
+	fontFamily: DEFAULT_MEME_FONT.fontFamily,
 	fontSize: fontSize ?? DEFAULT_FONT_SIZE,
 	fill: DEFAULT_PRIMARY_TEXT_COLOR,
 	textAlign: DEFAULT_TEXT_ALIGNMENT,

--- a/frontend/src/components/MemeEditor/translation.tsx
+++ b/frontend/src/components/MemeEditor/translation.tsx
@@ -4,11 +4,9 @@ import { Image as KonvaImage, Text } from "react-konva";
 import { randomID } from "../../util/util";
 import {
 	DEFAULT_DISPLAY_FONT_SIZE,
-	DEFAULT_FONT_FAMILY,
 	DEFAULT_ROTATION,
 	DEFAULT_SECONDARY_TEXT_COLOR,
 	DEFAULT_TEXT,
-	MIN_FONT_SIZE,
 	DEFAULT_X_OFFSET,
 	DEFAULT_Y_OFFSET,
 	EDITOR_PREVIEW_MAX_HEIGHT,
@@ -16,6 +14,7 @@ import {
 	type EditorImage,
 	type ImageHandlers,
 	type KeyType,
+	MIN_FONT_SIZE,
 	type NodeKey,
 	type Point,
 	type Textbox,
@@ -154,6 +153,7 @@ export const createTextbox = (
 	y: initialPosition.y,
 	rotation: DEFAULT_ROTATION,
 	fontSize: textStyle.fontSize,
+	fontFamily: textStyle.fontFamily,
 	fill: textStyle.fill,
 	textAlign: textStyle.textAlign,
 	strokeWidth: textStyle.strokeWidth,
@@ -195,7 +195,7 @@ export const textboxesToKonvaText = (
 			rotation={textbox.rotation}
 			width={textbox.width}
 			text={getTextboxDisplayText(textbox)}
-			fontFamily={DEFAULT_FONT_FAMILY}
+			fontFamily={textbox.fontFamily}
 			fontSize={textbox.fontSize}
 			fontStyle={getTextboxFontStyle(textbox)}
 			fill={textbox.fill}

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -8,7 +8,6 @@ export const DEFAULT_X_OFFSET = -100;
 export const DEFAULT_Y_OFFSET = 0;
 export const DEFAULT_ROTATION = 0;
 export const DEFAULT_TEXT_ALIGNMENT: TextAlignment = "center";
-export const DEFAULT_FONT_FAMILY = "Impact";
 export const DEFAULT_FONT_SIZE = 50;
 export const MIN_FONT_SIZE = 8;
 export const MIN_STROKE_WIDTH = 0;
@@ -38,10 +37,57 @@ export type EditorNode = Point & {
 	rotation: number;
 };
 
+export type MemeFont = {
+	label: string;
+	fontFamily: string;
+};
+
+export const MEME_FONTS: MemeFont[] = [
+	{
+		label: "Impact",
+		fontFamily: 'Impact, "Anton", sans-serif',
+	},
+	{
+		label: "Arial",
+		fontFamily: 'Arial, "Arimo", sans-serif',
+	},
+	{
+		label: "Arial Black",
+		fontFamily: '"Arial Black", "Archivo Black", sans-serif',
+	},
+	{
+		label: "Comic Sans MS",
+		fontFamily: '"Comic Sans MS", "Comic Neue", cursive',
+	},
+	{
+		label: "Montserrat",
+		fontFamily: '"Montserrat", sans-serif',
+	},
+	{
+		label: "Bebas Neue",
+		fontFamily: '"Bebas Neue", sans-serif',
+	},
+	{
+		label: "Oswald",
+		fontFamily: '"Oswald", sans-serif',
+	},
+	{
+		label: "Luckiest Guy",
+		fontFamily: '"Luckiest Guy", cursive',
+	},
+	{
+		label: "Bangers",
+		fontFamily: '"Bangers", cursive',
+	},
+];
+
+export const DEFAULT_MEME_FONT = MEME_FONTS[0];
+
 export type TextStyleScope = "global" | "selected";
 export type TextAlignment = "center" | "left" | "right";
 
 export type TextStyle = {
+	fontFamily: string;
 	fontSize: number;
 	fill: string;
 	textAlign: TextAlignment;


### PR DESCRIPTION
Currently the only font that is supported is Impact. This is not ideal because Impact is not installed on all computers and we don't have a fallback, and users may want to use other fonts.

I have added a dropdown with some popular fonts for memes. The fonts default to the most popular choices, but can also fallback to similar Google fonts if the popular font is not installed.