### PR TITLE
minor: support secondary color selection

### DIFF
--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -283,23 +283,25 @@ const FontFamilyInput = ({ disabledReason }: FontFamilyInputProps) => {
 	);
 };
 
-type TextColorInputProps = {
+type ColorInputProps = {
+	field: "primaryColor" | "secondaryColor";
+	label: string;
 	disabledReason: string;
 };
 
-const TextColorInput = ({ disabledReason }: TextColorInputProps) => {
+const ColorInput = ({ field, label, disabledReason }: ColorInputProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
-	const value = useMemeEditorStore((state) => state.getTextStyle("fill"));
+	const value = useMemeEditorStore((state) => state.getTextStyle(field));
 	const disabled = disabledReason !== "";
 
 	return (
 		<Tooltip message={disabledReason} active={disabled}>
 			<label>
-				Text color
+				{label}
 				<input
 					type="color"
 					value={value}
-					onChange={(event) => setTextStyle("fill", event.target.value)}
+					onChange={(event) => setTextStyle(field, event.target.value)}
 					disabled={disabled}
 				/>
 			</label>
@@ -641,7 +643,16 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 							/>
 						</div>
 						<div className="grid">
-							<TextColorInput disabledReason={disabledReason} />
+							<ColorInput
+								field="primaryColor"
+								label="Primary color"
+								disabledReason={disabledReason}
+							/>
+							<ColorInput
+								field="secondaryColor"
+								label="Secondary color"
+								disabledReason={disabledReason}
+							/>
 							<TextAlignmentInput disabledReason={disabledReason} />
 						</div>
 						<div className="grid">

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -4,6 +4,7 @@ import {
 	DEFAULT_FONT_SIZE,
 	DEFAULT_MEME_FONT,
 	DEFAULT_PRIMARY_TEXT_COLOR,
+	DEFAULT_SECONDARY_TEXT_COLOR,
 	DEFAULT_SHADOW_BLUR,
 	DEFAULT_STROKE_WIDTH,
 	DEFAULT_TEXT_ALIGNMENT,
@@ -87,7 +88,8 @@ const applyTextboxTransform = (
 const toTextStyle = (textbox: Textbox): TextStyle => ({
 	fontFamily: textbox.fontFamily,
 	fontSize: textbox.fontSize,
-	fill: textbox.fill,
+	primaryColor: textbox.primaryColor,
+	secondaryColor: textbox.secondaryColor,
 	textAlign: textbox.textAlign,
 	strokeWidth: textbox.strokeWidth,
 	shadowBlur: textbox.shadowBlur,
@@ -238,7 +240,8 @@ const applySelectedNodeDeletion = (
 const createDefaultTextStyle = (fontSize: number | null): TextStyle => ({
 	fontFamily: DEFAULT_MEME_FONT.fontFamily,
 	fontSize: fontSize ?? DEFAULT_FONT_SIZE,
-	fill: DEFAULT_PRIMARY_TEXT_COLOR,
+	primaryColor: DEFAULT_PRIMARY_TEXT_COLOR,
+	secondaryColor: DEFAULT_SECONDARY_TEXT_COLOR,
 	textAlign: DEFAULT_TEXT_ALIGNMENT,
 	strokeWidth: DEFAULT_STROKE_WIDTH,
 	shadowBlur: DEFAULT_SHADOW_BLUR,

--- a/frontend/src/components/MemeEditor/translation.tsx
+++ b/frontend/src/components/MemeEditor/translation.tsx
@@ -5,7 +5,6 @@ import { randomID } from "../../util/util";
 import {
 	DEFAULT_DISPLAY_FONT_SIZE,
 	DEFAULT_ROTATION,
-	DEFAULT_SECONDARY_TEXT_COLOR,
 	DEFAULT_TEXT,
 	DEFAULT_X_OFFSET,
 	DEFAULT_Y_OFFSET,
@@ -154,7 +153,8 @@ export const createTextbox = (
 	rotation: DEFAULT_ROTATION,
 	fontSize: textStyle.fontSize,
 	fontFamily: textStyle.fontFamily,
-	fill: textStyle.fill,
+	primaryColor: textStyle.primaryColor,
+	secondaryColor: textStyle.secondaryColor,
 	textAlign: textStyle.textAlign,
 	strokeWidth: textStyle.strokeWidth,
 	shadowBlur: textStyle.shadowBlur,
@@ -198,12 +198,12 @@ export const textboxesToKonvaText = (
 			fontFamily={textbox.fontFamily}
 			fontSize={textbox.fontSize}
 			fontStyle={getTextboxFontStyle(textbox)}
-			fill={textbox.fill}
+			fill={textbox.primaryColor}
 			align={textbox.textAlign}
 			textDecoration={getTextboxTextDecoration(textbox)}
-			stroke={DEFAULT_SECONDARY_TEXT_COLOR}
+			stroke={textbox.secondaryColor}
 			strokeWidth={textbox.strokeWidth}
-			shadowColor={DEFAULT_SECONDARY_TEXT_COLOR}
+			shadowColor={textbox.secondaryColor}
 			shadowBlur={textbox.shadowBlur}
 			draggable
 			onClick={() => handlers.onSelect(textbox.id)}

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -89,7 +89,8 @@ export type TextAlignment = "center" | "left" | "right";
 export type TextStyle = {
 	fontFamily: string;
 	fontSize: number;
-	fill: string;
+	primaryColor: string;
+	secondaryColor: string;
 	textAlign: TextAlignment;
 	strokeWidth: number;
 	shadowBlur: number;


### PR DESCRIPTION
Currently users can select a primary color, but the secondary color is always black. We should support selecting a different secondary color (which is used for the outline and shadow).

I have added a new color select for the secondary color.