### PR TITLE
minor: use api hooks instead of direct fetch calls

### DIFF
--- a/frontend/src/api/clients/http.client.ts
+++ b/frontend/src/api/clients/http.client.ts
@@ -1,0 +1,26 @@
+import { BACKEND_HOSTNAME } from "../../config";
+
+export class ApiError extends Error {
+	readonly status: number;
+
+	constructor(status: number, message: string) {
+		super(message);
+		this.name = "ApiError";
+		this.status = status;
+	}
+}
+
+const createUrl = (path: string) => new URL(path, BACKEND_HOSTNAME).toString();
+
+export const fetchJson = async <T>(
+	path: string,
+	init?: RequestInit,
+): Promise<T> => {
+	const response = await fetch(createUrl(path), init);
+
+	if (!response.ok) {
+		throw new ApiError(response.status, response.statusText);
+	}
+
+	return (await response.json()) as T;
+};

--- a/frontend/src/api/clients/meme-maker.client.ts
+++ b/frontend/src/api/clients/meme-maker.client.ts
@@ -1,0 +1,12 @@
+import type { MemeResponse } from "../../types/api";
+import { fetchJson } from "./http.client";
+
+export const memeMakerClient = {
+	getTop100Memes: () => fetchJson<MemeResponse>("/mememaker/top100"),
+	searchMemes: (searchTerm: string) =>
+		fetchJson<MemeResponse>(
+			`/mememaker/searchmemes?${new URLSearchParams({
+				searchterm: searchTerm,
+			}).toString()}`,
+		),
+};

--- a/frontend/src/api/clients/photos.client.ts
+++ b/frontend/src/api/clients/photos.client.ts
@@ -1,0 +1,6 @@
+import type { PhotoResponse } from "../../types/api";
+import { fetchJson } from "./http.client";
+
+export const photosClient = {
+	getSeattlePhoto: () => fetchJson<PhotoResponse>("/photos/seattle"),
+};

--- a/frontend/src/api/hooks/useMemeTemplates.ts
+++ b/frontend/src/api/hooks/useMemeTemplates.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import type { Meme } from "../../types/api";
+import type { Loadable } from "../../types/loadable";
+import { memeMakerClient } from "../clients/meme-maker.client";
+
+type UseMemeTemplatesResult = {
+	memes: Loadable<Meme[]>;
+	searchMemes: (searchTerm: string) => Promise<void>;
+};
+
+const toErrorMessage = (caughtError: unknown) =>
+	caughtError instanceof Error
+		? caughtError.message
+		: "Failed to load meme templates";
+
+export const useMemeTemplates = (): UseMemeTemplatesResult => {
+	const [memes, setMemes] = useState<Loadable<Meme[]>>({
+		state: "loading",
+	});
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const loadTopMemes = async () => {
+			setMemes({ state: "loading" });
+
+			try {
+				const response = await memeMakerClient.getTop100Memes();
+
+				if (!cancelled) {
+					setMemes({ state: "done", value: response.data.memes });
+				}
+			} catch (caughtError) {
+				if (!cancelled) {
+					setMemes({
+						state: "error",
+						message: toErrorMessage(caughtError),
+					});
+				}
+			}
+		};
+
+		void loadTopMemes();
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const searchMemes = async (searchTerm: string) => {
+		try {
+			setMemes({ state: "loading" });
+
+			const response = await memeMakerClient.searchMemes(searchTerm);
+			setMemes({ state: "done", value: response.data.memes });
+		} catch (caughtError) {
+			setMemes({
+				state: "error",
+				message: toErrorMessage(caughtError),
+			});
+		}
+	};
+
+	return { memes, searchMemes };
+};

--- a/frontend/src/api/hooks/useSeattlePhoto.ts
+++ b/frontend/src/api/hooks/useSeattlePhoto.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import type { PhotoResponse } from "../../types/api";
+import type { Loadable } from "../../types/loadable";
+import { photosClient } from "../clients/photos.client";
+
+const toErrorMessage = (caughtError: unknown) =>
+	caughtError instanceof Error
+		? caughtError.message
+		: "Failed to load Seattle photo";
+
+export const useSeattlePhoto = (): Loadable<PhotoResponse> => {
+	const [photo, setPhoto] = useState<Loadable<PhotoResponse>>({
+		state: "loading",
+	});
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const loadPhoto = async () => {
+			try {
+				setPhoto({ state: "loading" });
+
+				const response = await photosClient.getSeattlePhoto();
+
+				if (!cancelled) {
+					setPhoto({ state: "done", value: response });
+				}
+			} catch (caughtError) {
+				if (!cancelled) {
+					setPhoto({
+						state: "error",
+						message: toErrorMessage(caughtError),
+					});
+				}
+			}
+		};
+
+		void loadPhoto();
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	return photo;
+};

--- a/frontend/src/routes/home/HomeRoute.tsx
+++ b/frontend/src/routes/home/HomeRoute.tsx
@@ -1,21 +1,30 @@
-import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { BACKEND_HOSTNAME } from "../../config";
+import { useSeattlePhoto } from "../../api/hooks/useSeattlePhoto";
 import type { PhotoResponse } from "../../types/api";
+import { matchLoadable } from "../../types/loadable";
 import { Pages } from "../../types/pages";
 
+type ImageProps = {
+	photo: PhotoResponse;
+};
+
+const Image = ({ photo }: ImageProps) => {
+	return (
+		<>
+			<img src={photo.imageURL} alt="Seattle, WA" />
+			<figcaption>
+				Photo by{" "}
+				<a href={photo.author.profileURL}>
+					{`${photo.author.firstName} ${photo.author.lastName}`}
+				</a>{" "}
+				on <a href={photo.sourceURL}>{photo.sourceName}</a>
+			</figcaption>
+		</>
+	);
+};
+
 const HomeRoute = () => {
-	const [seattlePhoto, setSeattlePhoto] = useState<PhotoResponse | null>(null);
-
-	useEffect(() => {
-		const fetchPhoto = async () => {
-			const response = await fetch(`${BACKEND_HOSTNAME}/photos/seattle`);
-			const data = (await response.json()) as PhotoResponse;
-			setSeattlePhoto(data);
-		};
-
-		void fetchPhoto();
-	}, []);
+	const seattlePhoto = useSeattlePhoto();
 
 	return (
 		<>
@@ -28,15 +37,11 @@ const HomeRoute = () => {
 							Visit <Link to={Pages.MEME_MAKER}>Meme Maker here</Link>
 						</p>
 						<figure>
-							<img src={seattlePhoto?.imageURL} alt="Seattle, WA" />
-							<figcaption>
-								Photo by{" "}
-								<a href={seattlePhoto?.author.profileURL}>
-									{`${seattlePhoto?.author.firstName ?? ""} ${seattlePhoto?.author.lastName ?? ""}`}
-								</a>{" "}
-								on{" "}
-								<a href={seattlePhoto?.sourceURL}>{seattlePhoto?.sourceName}</a>
-							</figcaption>
+							{matchLoadable(seattlePhoto, {
+								loading: () => <p aria-busy="true">Loading photo...</p>,
+								error: (error) => <p>{error.message}</p>,
+								done: (done) => <Image photo={done.value} />,
+							})}
 						</figure>
 					</div>
 				</article>

--- a/frontend/src/routes/meme-maker/templates/TemplateListRoute.tsx
+++ b/frontend/src/routes/meme-maker/templates/TemplateListRoute.tsx
@@ -1,7 +1,9 @@
-import { type SyntheticEvent, useEffect, useMemo, useState } from "react";
+import { type SyntheticEvent, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { BACKEND_HOSTNAME } from "../../../config";
-import type { Meme, MemeResponse } from "../../../types/api";
+import { useMemeTemplates } from "../../../api/hooks/useMemeTemplates";
+import type { Meme } from "../../../types/api";
+import { matchLoadable } from "../../../types/loadable";
+import { Pages } from "../../../types/pages";
 
 const MEMES_PER_ROW = 5;
 
@@ -22,38 +24,68 @@ const toRows = (memes: Meme[]): Meme[][] => {
 	return rows;
 };
 
+type TemplateProps = {
+	meme: Meme;
+};
+
+const createTemplateHref = (meme: Meme) => {
+	const path = Pages.MEME_MAKER_TEMPLATE.replace(":templateID", "temp");
+	const params = new URLSearchParams({
+		name: meme.name,
+		templateUrl: encodeURIComponent(meme.url),
+	}).toString();
+
+	return `${path}?${params}`;
+};
+
+const Template = ({ meme }: TemplateProps) => {
+	const href = createTemplateHref(meme);
+
+	return (
+		<article>
+			<Link to={href}>
+				<img
+					src={meme.url}
+					alt={meme.name}
+					style={{
+						maxWidth: "150px",
+						maxHeight: "150px",
+						width: "auto",
+						height: "auto",
+					}}
+				/>
+			</Link>
+			<p>
+				<Link to={href}>{meme.name}</Link>
+			</p>
+		</article>
+	);
+};
+
+const renderRows = (rows: Meme[][]) =>
+	rows.map((row, rowIndex) => (
+		<div className="grid" key={`row-${rowIndex.toString()}`}>
+			{row.map((meme) => (
+				<Template key={meme.id} meme={meme} />
+			))}
+		</div>
+	));
+
 export const TemplateListRoute = () => {
-	const [loading, setLoading] = useState<boolean>(true);
 	const [searchQuery, setSearchQuery] = useState<string>("");
-	const [memeResults, setMemeResults] = useState<Meme[]>([]);
-
-	useEffect(() => {
-		const fetchTopMemes = async () => {
-			const response = await fetch(`${BACKEND_HOSTNAME}/mememaker/top100`);
-			const responseData = (await response.json()) as MemeResponse;
-			setMemeResults(responseData.data.memes);
-			setLoading(false);
-		};
-
-		void fetchTopMemes();
-	}, []);
+	const { memes, searchMemes } = useMemeTemplates();
 
 	const onSearch = async (event: SyntheticEvent<HTMLFormElement>) => {
 		event.preventDefault();
-		setLoading(true);
-
-		const response = await fetch(
-			`${BACKEND_HOSTNAME}/mememaker/searchmemes?${new URLSearchParams({
-				searchterm: searchQuery,
-			}).toString()}`,
-		);
-
-		const responseData = (await response.json()) as MemeResponse;
-		setMemeResults(responseData.data.memes);
-		setLoading(false);
+		await searchMemes(searchQuery);
 	};
 
-	const rows = useMemo(() => toRows(memeResults), [memeResults]);
+	const rows = useMemo(() => {
+		if (memes.state !== "done") {
+			return [];
+		}
+		return toRows(memes.value);
+	}, [memes]);
 
 	return (
 		<>
@@ -70,41 +102,11 @@ export const TemplateListRoute = () => {
 						/>
 						<button type="submit">Search Templates</button>
 					</form>
-					{loading ? (
-						<p aria-busy="true">Loading results...</p>
-					) : (
-						rows.map((row, rowIndex) => (
-							<div className="grid" key={`row-${rowIndex.toString()}`}>
-								{row.map((meme) => {
-									const params = new URLSearchParams({
-										name: meme.name,
-										templateUrl: encodeURIComponent(meme.url),
-									}).toString();
-									const href = `/MemeMaker/template/temp?${params}`;
-
-									return (
-										<article key={meme.id}>
-											<Link to={href}>
-												<img
-													src={meme.url}
-													alt={meme.name}
-													style={{
-														maxWidth: "150px",
-														maxHeight: "150px",
-														width: "auto",
-														height: "auto",
-													}}
-												/>
-											</Link>
-											<p>
-												<Link to={href}>{meme.name}</Link>
-											</p>
-										</article>
-									);
-								})}
-							</div>
-						))
-					)}
+					{matchLoadable(memes, {
+						loading: () => <p aria-busy="true">Loading results...</p>,
+						error: (error) => <p>{error.message}</p>,
+						done: () => <>{renderRows(rows)}</>,
+					})}
 				</article>
 			</main>
 		</>

--- a/frontend/src/types/loadable.ts
+++ b/frontend/src/types/loadable.ts
@@ -1,0 +1,35 @@
+export type Loading = {
+	state: "loading";
+};
+
+export type Error = {
+	state: "error";
+	message: string;
+};
+
+export type Done<T> = {
+	state: "done";
+	value: T;
+};
+
+export type Loadable<T> = Loading | Error | Done<T>;
+
+type LoadableMatchers<T, TResult> = {
+	loading: (loading: Loading) => TResult;
+	error: (error: Error) => TResult;
+	done: (done: Done<T>) => TResult;
+};
+
+export const matchLoadable = <T, TResult>(
+	loadable: Loadable<T>,
+	matchers: LoadableMatchers<T, TResult>,
+): TResult => {
+	switch (loadable.state) {
+		case "loading":
+			return matchers.loading(loadable);
+		case "error":
+			return matchers.error(loadable);
+		case "done":
+			return matchers.done(loadable);
+	}
+};


### PR DESCRIPTION
Previously we were directly using `fetch()` to call API endpoints from components. This is not ideal because components shouldn't need to know about the specific API endpoint, and they shouldn't be responsible for making the request.

I have added new API functions to call the backend, and hooks that the components can use. I have also added a new `Loadable<T>` type to help with loading/error states.