### PR TITLE
chore: load meme maker background from routes

### DIFF
--- a/frontend/src/api/hooks/useMemeTemplates.ts
+++ b/frontend/src/api/hooks/useMemeTemplates.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
 import type { Meme } from "../../types/api";
-import type { Loadable } from "../../types/loadable";
+import {
+	createDone,
+	createError,
+	createLoading,
+	type Loadable,
+} from "../../types/loadable";
 import { memeMakerClient } from "../clients/meme-maker.client";
 
 type UseMemeTemplatesResult = {
@@ -14,28 +19,23 @@ const toErrorMessage = (caughtError: unknown) =>
 		: "Failed to load meme templates";
 
 export const useMemeTemplates = (): UseMemeTemplatesResult => {
-	const [memes, setMemes] = useState<Loadable<Meme[]>>({
-		state: "loading",
-	});
+	const [memes, setMemes] = useState<Loadable<Meme[]>>(createLoading());
 
 	useEffect(() => {
 		let cancelled = false;
 
 		const loadTopMemes = async () => {
-			setMemes({ state: "loading" });
+			setMemes(createLoading());
 
 			try {
 				const response = await memeMakerClient.getTop100Memes();
 
 				if (!cancelled) {
-					setMemes({ state: "done", value: response.data.memes });
+					setMemes(createDone(response.data.memes));
 				}
 			} catch (caughtError) {
 				if (!cancelled) {
-					setMemes({
-						state: "error",
-						message: toErrorMessage(caughtError),
-					});
+					setMemes(createError(toErrorMessage(caughtError)));
 				}
 			}
 		};
@@ -49,15 +49,12 @@ export const useMemeTemplates = (): UseMemeTemplatesResult => {
 
 	const searchMemes = async (searchTerm: string) => {
 		try {
-			setMemes({ state: "loading" });
+			setMemes(createLoading());
 
 			const response = await memeMakerClient.searchMemes(searchTerm);
-			setMemes({ state: "done", value: response.data.memes });
+			setMemes(createDone(response.data.memes));
 		} catch (caughtError) {
-			setMemes({
-				state: "error",
-				message: toErrorMessage(caughtError),
-			});
+			setMemes(createError(toErrorMessage(caughtError)));
 		}
 	};
 

--- a/frontend/src/api/hooks/useSeattlePhoto.ts
+++ b/frontend/src/api/hooks/useSeattlePhoto.ts
@@ -1,6 +1,11 @@
 import { useEffect, useState } from "react";
 import type { PhotoResponse } from "../../types/api";
-import type { Loadable } from "../../types/loadable";
+import {
+	createDone,
+	createError,
+	createLoading,
+	type Loadable,
+} from "../../types/loadable";
 import { photosClient } from "../clients/photos.client";
 
 const toErrorMessage = (caughtError: unknown) =>
@@ -9,28 +14,23 @@ const toErrorMessage = (caughtError: unknown) =>
 		: "Failed to load Seattle photo";
 
 export const useSeattlePhoto = (): Loadable<PhotoResponse> => {
-	const [photo, setPhoto] = useState<Loadable<PhotoResponse>>({
-		state: "loading",
-	});
+	const [photo, setPhoto] = useState<Loadable<PhotoResponse>>(createLoading());
 
 	useEffect(() => {
 		let cancelled = false;
 
 		const loadPhoto = async () => {
 			try {
-				setPhoto({ state: "loading" });
+				setPhoto(createLoading());
 
 				const response = await photosClient.getSeattlePhoto();
 
 				if (!cancelled) {
-					setPhoto({ state: "done", value: response });
+					setPhoto(createDone(response));
 				}
 			} catch (caughtError) {
 				if (!cancelled) {
-					setPhoto({
-						state: "error",
-						message: toErrorMessage(caughtError),
-					});
+					setPhoto(createError(toErrorMessage(caughtError)));
 				}
 			}
 		};

--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -5,8 +5,8 @@ import {
 	useEffect,
 	useMemo,
 	useRef,
-	useState,
 } from "react";
+import { loadImage } from "../../util/images";
 import { Tooltip } from "../Tooltip";
 import { Canvas, type CanvasHandle } from "./Canvas";
 import styles from "./MemeEditor.module.css";
@@ -20,7 +20,6 @@ import {
 	parseNodeKey,
 } from "./translation";
 import type {
-	BackgroundSource,
 	NodeKey,
 	TextAlignment,
 	TextStyle,
@@ -37,19 +36,10 @@ import {
 } from "./types";
 
 export type MemeEditorProps = {
-	background: BackgroundSource;
+	backgroundImage: HTMLImageElement;
 };
 
 const textAlignments: TextAlignment[] = ["center", "left", "right"];
-
-const loadImage = (url: string) => {
-	return new Promise<HTMLImageElement>((resolve, reject) => {
-		const image = new window.Image();
-		image.onload = () => resolve(image);
-		image.onerror = () => reject(new Error(`Failed to load image from ${url}`));
-		image.src = url;
-	});
-};
 
 const getTextInputDeactivatedReason = (
 	textStyleScope: TextStyleScope,
@@ -521,7 +511,7 @@ const CopyMemeButton = ({ getMemeBlob }: CopyMemeButtonProps) => {
 	);
 };
 
-export const MemeEditor = ({ background }: MemeEditorProps) => {
+export const MemeEditor = ({ backgroundImage }: MemeEditorProps) => {
 	const globalTextStyle = useMemeEditorStore((state) => state.globalTextStyle);
 	const textStyleScope = useMemeEditorStore((state) => state.textStyleScope);
 	const selectedNodeKey = useMemeEditorStore((state) => state.selectedNodeKey);
@@ -531,8 +521,6 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 	const setDefaultFontSize = useMemeEditorStore(
 		(state) => state.setDefaultFontSize,
 	);
-	const [backgroundImage, setBackgroundImage] =
-		useState<HTMLImageElement | null>(null);
 	const canvasRef = useRef<CanvasHandle>(null);
 
 	const downloadBlob = useCallback(async () => {
@@ -545,52 +533,10 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 	}, []);
 
 	useEffect(() => {
-		const controller = new AbortController();
-		let objectUrl = "";
-		setBackgroundImage(null);
 		resetEditor();
-
-		const hydrateBackground = async () => {
-			try {
-				if (background.kind === "file") {
-					objectUrl = URL.createObjectURL(background.file);
-				} else {
-					const response = await fetch(background.url, {
-						signal: controller.signal,
-					});
-					const imageBlob = await response.blob();
-					objectUrl = URL.createObjectURL(imageBlob);
-				}
-
-				const loadedBackgroundImage = await loadImage(objectUrl);
-				if (controller.signal.aborted) {
-					return;
-				}
-
-				setBackgroundImage(loadedBackgroundImage);
-			} catch (error) {
-				if (controller.signal.aborted) {
-					return;
-				}
-
-				console.error("Failed to load background image", error);
-			}
-		};
-
-		void hydrateBackground();
-
-		return () => {
-			controller.abort();
-			if (objectUrl) {
-				URL.revokeObjectURL(objectUrl);
-			}
-		};
-	}, [background, resetEditor]);
+	}, [resetEditor]);
 
 	const previewScale = useMemo(() => {
-		if (!backgroundImage) {
-			return 1;
-		}
 		return getPreviewScale(backgroundImage);
 	}, [backgroundImage]);
 	const disabledReason = getTextInputDeactivatedReason(
@@ -602,10 +548,6 @@ export const MemeEditor = ({ background }: MemeEditorProps) => {
 		const defaultFontSize = getDefaultFontSize(previewScale);
 		setDefaultFontSize(defaultFontSize);
 	}, [previewScale, setDefaultFontSize]);
-
-	if (!backgroundImage) {
-		return <p>Loading canvas...</p>;
-	}
 
 	return (
 		<>

--- a/frontend/src/components/MemeEditor/index.ts
+++ b/frontend/src/components/MemeEditor/index.ts
@@ -1,0 +1,1 @@
+export { MemeEditor } from "./MemeEditor";

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -20,10 +20,6 @@ export const MAX_SHADOW_BLUR = 50;
 export const DEFAULT_SHADOW_BLUR = 30;
 export const IMAGE_MIME_TYPE = "image/png";
 
-export type BackgroundSource =
-	| { kind: "file"; file: File }
-	| { kind: "url"; url: string };
-
 export type KeyType = "text" | "image";
 export type NodeKey = `${KeyType}:${string}`;
 

--- a/frontend/src/routes/meme-maker/edit/TemplateEditorRoute.tsx
+++ b/frontend/src/routes/meme-maker/edit/TemplateEditorRoute.tsx
@@ -1,10 +1,59 @@
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { MemeEditor } from "../../../components/MemeEditor/MemeEditor";
+import { MemeEditor } from "../../../components/MemeEditor";
+import {
+	createDone,
+	createError,
+	createLoading,
+	type Loadable,
+	matchLoadable,
+} from "../../../types/loadable";
+import { loadImage } from "../../../util/images";
+
+const fetchImageBlob = async (imageUrl: string, signal: AbortSignal) => {
+	const response = await fetch(imageUrl, { signal });
+	if (!response.ok) {
+		throw new Error(`Failed to fetch image: ${response.status}`);
+	}
+
+	return response.blob();
+};
+
+const loadBackgroundImageFromUrl = async (
+	imageUrl: string,
+	signal: AbortSignal,
+) => {
+	const imageBlob = await fetchImageBlob(imageUrl, signal);
+	const objectUrl = URL.createObjectURL(imageBlob);
+
+	try {
+		const image = await loadImage(objectUrl);
+		return {
+			image,
+			objectUrl,
+		};
+	} catch (error) {
+		URL.revokeObjectURL(objectUrl);
+		throw error;
+	}
+};
+
+const cleanupObjectUrl = (objectUrl: string) => {
+	if (objectUrl) {
+		URL.revokeObjectURL(objectUrl);
+	}
+};
+
+const toErrorMessage = (caughtError: unknown) =>
+	caughtError instanceof Error ? caughtError.message : "Failed to load editor";
 
 export const TemplateEditorRoute = () => {
 	const [searchParams] = useSearchParams();
 	const name = searchParams.get("name");
 	const templateUrlEncoded = searchParams.get("templateUrl");
+	const [backgroundImage, setBackgroundImage] = useState<
+		Loadable<HTMLImageElement>
+	>(createLoading());
 
 	if (!name || !templateUrlEncoded) {
 		throw new Error("Missing template name and/or URL");
@@ -12,18 +61,53 @@ export const TemplateEditorRoute = () => {
 
 	const templateUrl = decodeURIComponent(templateUrlEncoded);
 
+	useEffect(() => {
+		const controller = new AbortController();
+		let objectUrl = "";
+		setBackgroundImage(createLoading());
+
+		const hydrateBackgroundImage = async () => {
+			try {
+				const result = await loadBackgroundImageFromUrl(
+					templateUrl,
+					controller.signal,
+				);
+				if (controller.signal.aborted) {
+					cleanupObjectUrl(result.objectUrl);
+					return;
+				}
+
+				objectUrl = result.objectUrl;
+				setBackgroundImage(createDone(result.image));
+			} catch (error) {
+				if (controller.signal.aborted) {
+					return;
+				}
+
+				console.error("Failed to load background image", error);
+				setBackgroundImage(createError(toErrorMessage(error)));
+			}
+		};
+
+		void hydrateBackgroundImage();
+
+		return () => {
+			controller.abort();
+			cleanupObjectUrl(objectUrl);
+		};
+	}, [templateUrl]);
+
 	return (
 		<>
 			<title>Meme Maker - {name}</title>
 			<main className="container">
 				<article>
 					<h2>Meme Template: {name}</h2>
-					<MemeEditor
-						background={{
-							kind: "url",
-							url: templateUrl,
-						}}
-					/>
+					{matchLoadable(backgroundImage, {
+						loading: () => <p aria-busy="true">Loading editor...</p>,
+						error: (error) => <p>{error.message}</p>,
+						done: (image) => <MemeEditor backgroundImage={image.value} />,
+					})}
 				</article>
 			</main>
 		</>

--- a/frontend/src/routes/meme-maker/new/NewTemplateRoute.tsx
+++ b/frontend/src/routes/meme-maker/new/NewTemplateRoute.tsx
@@ -1,13 +1,114 @@
-import { type ChangeEvent, useState } from "react";
-import { MemeEditor } from "../../../components/MemeEditor/MemeEditor";
+import { type ChangeEvent, useEffect, useState } from "react";
+import { MemeEditor } from "../../../components/MemeEditor";
+import {
+	createDone,
+	createError,
+	createLoading,
+	type Loadable,
+	matchLoadable,
+} from "../../../types/loadable";
+import { loadImage } from "../../../util/images";
+
+const loadBackgroundImageFromFile = async (templateFile: File) => {
+	const objectUrl = URL.createObjectURL(templateFile);
+
+	try {
+		const image = await loadImage(objectUrl);
+		return {
+			image,
+			objectUrl,
+		};
+	} catch (error) {
+		URL.revokeObjectURL(objectUrl);
+		throw error;
+	}
+};
+
+const cleanupObjectUrl = (objectUrl: string) => {
+	if (objectUrl) {
+		URL.revokeObjectURL(objectUrl);
+	}
+};
+
+const toErrorMessage = (caughtError: unknown) =>
+	caughtError instanceof Error ? caughtError.message : "Failed to load editor";
+
+type TemplatePickerProps = {
+	onTemplateSelected: (file: File | null) => void;
+};
+
+const TemplatePicker = ({ onTemplateSelected }: TemplatePickerProps) => {
+	const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+		onTemplateSelected(event.target.files?.[0] ?? null);
+	};
+
+	return (
+		<>
+			<form>
+				<input
+					type="file"
+					id="template"
+					name="template"
+					accept="image/*"
+					onChange={handleChange}
+				/>
+			</form>
+			<p>Please upload a meme template.</p>
+		</>
+	);
+};
+
+type TemplateEditorLoaderProps = {
+	templateFile: File;
+};
+
+const TemplateEditorLoader = ({ templateFile }: TemplateEditorLoaderProps) => {
+	const [backgroundImage, setBackgroundImage] = useState<
+		Loadable<HTMLImageElement>
+	>(createLoading());
+
+	useEffect(() => {
+		let isActive = true;
+		let objectUrl = "";
+		setBackgroundImage(createLoading());
+
+		const hydrateBackgroundImage = async () => {
+			try {
+				const result = await loadBackgroundImageFromFile(templateFile);
+				if (!isActive) {
+					cleanupObjectUrl(result.objectUrl);
+					return;
+				}
+
+				objectUrl = result.objectUrl;
+				setBackgroundImage(createDone(result.image));
+			} catch (error) {
+				if (!isActive) {
+					return;
+				}
+
+				console.error("Failed to load background image", error);
+				setBackgroundImage(createError(toErrorMessage(error)));
+			}
+		};
+
+		void hydrateBackgroundImage();
+
+		return () => {
+			isActive = false;
+			cleanupObjectUrl(objectUrl);
+		};
+	}, [templateFile]);
+
+	return matchLoadable(backgroundImage, {
+		loading: () => <p aria-busy="true">Loading editor...</p>,
+		error: (error) => <p>{error.message}</p>,
+		done: (image) => <MemeEditor backgroundImage={image.value} />,
+	});
+};
 
 export const NewTemplateRoute = () => {
 	const [templateFile, setTemplateFile] = useState<File | null>(null);
-
-	const onTemplateSelected = (event: ChangeEvent<HTMLInputElement>) => {
-		const file = event.target.files?.[0] ?? null;
-		setTemplateFile(file);
-	};
 
 	return (
 		<>
@@ -15,27 +116,10 @@ export const NewTemplateRoute = () => {
 			<main className="container">
 				<article>
 					<h2>New Meme Maker Template</h2>
-					{!templateFile && (
-						<>
-							<form>
-								<input
-									type="file"
-									id="template"
-									name="template"
-									accept="image/*"
-									onChange={onTemplateSelected}
-								/>
-							</form>
-							<p>Please upload a meme template.</p>
-						</>
-					)}
-					{templateFile && (
-						<MemeEditor
-							background={{
-								kind: "file",
-								file: templateFile,
-							}}
-						/>
+					{templateFile ? (
+						<TemplateEditorLoader templateFile={templateFile} />
+					) : (
+						<TemplatePicker onTemplateSelected={setTemplateFile} />
 					)}
 				</article>
 			</main>

--- a/frontend/src/types/loadable.ts
+++ b/frontend/src/types/loadable.ts
@@ -14,6 +14,20 @@ export type Done<T> = {
 
 export type Loadable<T> = Loading | Error | Done<T>;
 
+export const createLoading = (): Loading => ({
+	state: "loading",
+});
+
+export const createError = (message: string): Error => ({
+	state: "error",
+	message,
+});
+
+export const createDone = <T>(value: T): Done<T> => ({
+	state: "done",
+	value,
+});
+
 type LoadableMatchers<T, TResult> = {
 	loading: (loading: Loading) => TResult;
 	error: (error: Error) => TResult;

--- a/frontend/src/util/images.ts
+++ b/frontend/src/util/images.ts
@@ -1,0 +1,7 @@
+export const loadImage = (url: string) =>
+	new Promise<HTMLImageElement>((resolve, reject) => {
+		const image = new window.Image();
+		image.onload = () => resolve(image);
+		image.onerror = () => reject(new Error(`Failed to load image from ${url}`));
+		image.src = url;
+	});


### PR DESCRIPTION
Currently the meme editor takes in multiple different ways of loading a background and handles the loading itself. This should really just be done by the routes using the editor.

Refactored the routes to do the background image loading themselves.