### PR TITLE
fix: canvas does not render selected font

### DIFF
--- a/frontend/src/components/MemeEditor/MemeEditor.tsx
+++ b/frontend/src/components/MemeEditor/MemeEditor.tsx
@@ -5,10 +5,12 @@ import {
 	useEffect,
 	useMemo,
 	useRef,
+	useState,
 } from "react";
 import { loadImage } from "../../util/images";
 import { Tooltip } from "../Tooltip";
 import { Canvas, type CanvasHandle } from "./Canvas";
+import { preloadMemeFonts, TEXT_FONTS } from "./fonts";
 import styles from "./MemeEditor.module.css";
 import { useMemeEditorStore } from "./store";
 import {
@@ -29,7 +31,6 @@ import {
 	IMAGE_MIME_TYPE,
 	MAX_SHADOW_BLUR,
 	MAX_STROKE_WIDTH,
-	MEME_FONTS,
 	MIN_FONT_SIZE,
 	MIN_SHADOW_BLUR,
 	MIN_STROKE_WIDTH,
@@ -244,10 +245,25 @@ type FontFamilyInputProps = {
 const FontFamilyInput = ({ disabledReason }: FontFamilyInputProps) => {
 	const setTextStyle = useMemeEditorStore((state) => state.setTextStyle);
 	const value = useMemeEditorStore((state) => state.getTextStyle("fontFamily"));
-	const disabled = disabledReason !== "";
+	const [fontsReady, setFontsReady] = useState(false);
+	const disabled = disabledReason !== "" || !fontsReady;
+
+	useEffect(() => {
+		let cancelled = false;
+
+		void preloadMemeFonts().then(() => {
+			if (!cancelled) {
+				setFontsReady(true);
+			}
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, []);
 
 	const options = useMemo(() => {
-		const fontFamilies = MEME_FONTS.map((font) => {
+		const fontFamilies = TEXT_FONTS.map((font) => {
 			return (
 				<option value={font.fontFamily} key={font.label}>
 					{font.label}
@@ -266,7 +282,11 @@ const FontFamilyInput = ({ disabledReason }: FontFamilyInputProps) => {
 					onChange={(event) => setTextStyle("fontFamily", event.target.value)}
 					disabled={disabled}
 				>
-					{options}
+					{fontsReady ? (
+						options
+					) : (
+						<option value={value}>Loading fonts...</option>
+					)}
 				</select>
 			</label>
 		</Tooltip>
@@ -528,7 +548,6 @@ export const MemeEditor = ({ backgroundImage }: MemeEditorProps) => {
 		if (!canvas) {
 			throw new Error("Canvas export is not ready");
 		}
-		await document.fonts.ready;
 		return canvas.exportBlob();
 	}, []);
 

--- a/frontend/src/components/MemeEditor/fonts.ts
+++ b/frontend/src/components/MemeEditor/fonts.ts
@@ -1,0 +1,97 @@
+import type { TextFont } from "./types";
+
+export const TEXT_FONTS: TextFont[] = [
+	{
+		label: "Impact",
+		fontFamily: 'Impact, "Anton", sans-serif',
+	},
+	{
+		label: "Arial",
+		fontFamily: 'Arial, "Arimo", sans-serif',
+	},
+	{
+		label: "Arial Black",
+		fontFamily: '"Arial Black", "Archivo Black", sans-serif',
+	},
+	{
+		label: "Comic Sans MS",
+		fontFamily: '"Comic Sans MS", "Comic Neue", cursive',
+	},
+	{
+		label: "Montserrat",
+		fontFamily: '"Montserrat", sans-serif',
+	},
+	{
+		label: "Bebas Neue",
+		fontFamily: '"Bebas Neue", sans-serif',
+	},
+	{
+		label: "Oswald",
+		fontFamily: '"Oswald", sans-serif',
+	},
+	{
+		label: "Luckiest Guy",
+		fontFamily: '"Luckiest Guy", cursive',
+	},
+	{
+		label: "Bangers",
+		fontFamily: '"Bangers", cursive',
+	},
+];
+
+export const DEFAULT_TEXT_FONT = TEXT_FONTS[0];
+
+type TextFontVariant = {
+	style: "normal" | "italic";
+	weight: "400" | "700";
+};
+
+const TEXT_FONT_VARIANTS: TextFontVariant[] = [
+	{ style: "normal", weight: "400" },
+	{ style: "normal", weight: "700" },
+	{ style: "italic", weight: "400" },
+	{ style: "italic", weight: "700" },
+];
+
+const GENERIC_FONT_FAMILIES = new Set([
+	"cursive",
+	"fantasy",
+	"monospace",
+	"sans-serif",
+	"serif",
+	"system-ui",
+]);
+
+const stripQuotes = (fontFamily: string) => {
+	return fontFamily.replace(/^['"]|['"]$/g, "");
+};
+
+export const getFontFamilies = (fontStack: string) => {
+	return fontStack
+		.split(",")
+		.map((family) => stripQuotes(family.trim()))
+		.filter(
+			(family) => family.length > 0 && !GENERIC_FONT_FAMILIES.has(family),
+		);
+};
+
+const loadFontFamily = (fontFamily: string, variant: TextFontVariant) => {
+	return document.fonts.load(
+		`${variant.style} ${variant.weight} 16px "${fontFamily}"`,
+	);
+};
+
+export const preloadFontStack = async (fontStack: string) => {
+	const families = getFontFamilies(fontStack);
+	await Promise.all(
+		families.flatMap((family) =>
+			TEXT_FONT_VARIANTS.map((variant) => loadFontFamily(family, variant)),
+		),
+	);
+};
+
+export const preloadMemeFonts = async () => {
+	await Promise.all(
+		TEXT_FONTS.map(({ fontFamily }) => preloadFontStack(fontFamily)),
+	);
+};

--- a/frontend/src/components/MemeEditor/store.ts
+++ b/frontend/src/components/MemeEditor/store.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
+import { DEFAULT_TEXT_FONT } from "./fonts";
 import { parseNodeKey, updateTextbox } from "./translation";
 import {
 	DEFAULT_FONT_SIZE,
-	DEFAULT_MEME_FONT,
 	DEFAULT_PRIMARY_TEXT_COLOR,
 	DEFAULT_SECONDARY_TEXT_COLOR,
 	DEFAULT_SHADOW_BLUR,
@@ -238,7 +238,7 @@ const applySelectedNodeDeletion = (
 };
 
 const createDefaultTextStyle = (fontSize: number | null): TextStyle => ({
-	fontFamily: DEFAULT_MEME_FONT.fontFamily,
+	fontFamily: DEFAULT_TEXT_FONT.fontFamily,
 	fontSize: fontSize ?? DEFAULT_FONT_SIZE,
 	primaryColor: DEFAULT_PRIMARY_TEXT_COLOR,
 	secondaryColor: DEFAULT_SECONDARY_TEXT_COLOR,

--- a/frontend/src/components/MemeEditor/types.ts
+++ b/frontend/src/components/MemeEditor/types.ts
@@ -33,51 +33,10 @@ export type EditorNode = Point & {
 	rotation: number;
 };
 
-export type MemeFont = {
+export type TextFont = {
 	label: string;
 	fontFamily: string;
 };
-
-export const MEME_FONTS: MemeFont[] = [
-	{
-		label: "Impact",
-		fontFamily: 'Impact, "Anton", sans-serif',
-	},
-	{
-		label: "Arial",
-		fontFamily: 'Arial, "Arimo", sans-serif',
-	},
-	{
-		label: "Arial Black",
-		fontFamily: '"Arial Black", "Archivo Black", sans-serif',
-	},
-	{
-		label: "Comic Sans MS",
-		fontFamily: '"Comic Sans MS", "Comic Neue", cursive',
-	},
-	{
-		label: "Montserrat",
-		fontFamily: '"Montserrat", sans-serif',
-	},
-	{
-		label: "Bebas Neue",
-		fontFamily: '"Bebas Neue", sans-serif',
-	},
-	{
-		label: "Oswald",
-		fontFamily: '"Oswald", sans-serif',
-	},
-	{
-		label: "Luckiest Guy",
-		fontFamily: '"Luckiest Guy", cursive',
-	},
-	{
-		label: "Bangers",
-		fontFamily: '"Bangers", cursive',
-	},
-];
-
-export const DEFAULT_MEME_FONT = MEME_FONTS[0];
 
 export type TextStyleScope = "global" | "selected";
 export type TextAlignment = "center" | "left" | "right";

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "root",
-  "private": true,
-  "packageManager": "pnpm@10.31.0",
-  "scripts": {
-    "dev": "pnpm -r --parallel --stream --filter backend --filter frontend dev",
-    "build": "pnpm -r build",
-    "check": "pnpm -r check",
-    "lint": "pnpm -r lint",
-    "format": "pnpm -r format"
-  }
+	"name": "root",
+	"private": true,
+	"packageManager": "pnpm@10.31.0",
+	"scripts": {
+		"dev": "pnpm -r --parallel --stream --filter backend --filter frontend dev",
+		"build": "pnpm -r build",
+		"check": "pnpm -r check",
+		"lint": "pnpm -r lint",
+		"format": "pnpm -r format"
+	}
 }


### PR DESCRIPTION
There's a bug when you select a font from the dropdown. The canvas won't actually render the selected font until you make other changes that force the canvas to re-draw, e.g. by moving the textbox around. This is because the browser doesn't load the font until it is needed.

See here for more info from Konva: https://konvajs.org/docs/sandbox/Custom_Font.html

I have updated the code to pre-load fonts and not allow the user to select a font until the fonts have finished loading.

There's still a potential edge case where the initial font hasn't finished loading when the user creates their first textbox, but since the network request is probably going to be a lot faster than the user clicking a button, I'm not too worried about this case.