### PR TITLE
chore: add commit hooks

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,9 +7,10 @@
 		"dev": "tsx watch ./src/server.ts | pino-pretty",
 		"build": "rm -rf ./build && tsc",
 		"start": "node ./build/server.js",
-		"check": "biome check .",
+		"format": "biome format --write .",
 		"lint": "biome lint .",
-		"format": "biome format --write ."
+		"check": "biome check .",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@aws-sdk/client-dynamodb": "^3.1004.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,9 +7,10 @@
 		"dev": "vite dev",
 		"build": "tsc -b && vite build",
 		"preview": "vite preview",
-		"check": "biome check .",
+		"format": "biome format --write .",
 		"lint": "biome lint .",
-		"format": "biome format --write ."
+		"check": "biome check .",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"dotenv": "catalog:",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,10 @@
+pre-commit:
+  parallel: true
+  commands:
+    check:
+      glob: "*.{ts,tsx,json,css,html}"
+      run: pnpm exec biome check --write --no-errors-on-unmatched {staged_files}
+      stage_fixed: true
+    typecheck:
+      glob: "*.{ts,tsx}"
+      run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
 	"private": true,
 	"packageManager": "pnpm@10.31.0",
 	"scripts": {
+		"prepare": "lefthook install",
 		"dev": "pnpm -r --parallel --stream --filter backend --filter frontend dev",
 		"build": "pnpm -r build",
-		"check": "pnpm -r check",
+		"format": "pnpm -r format",
 		"lint": "pnpm -r lint",
-		"format": "pnpm -r format"
+		"check": "pnpm -r check",
+		"typecheck": "pnpm -r typecheck"
+	},
+	"devDependencies": {
+		"lefthook": "^2.1.9"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,11 @@ catalogs:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.9
 
   backend:
     dependencies:
@@ -1396,6 +1400,60 @@ packages:
 
   konva@10.2.0:
     resolution: {integrity: sha512-JBoz0Xjbf49UPxCZegZ4WseqOzJ+C4AUDOtJ9eBve5RS5Fcq/u8TdBD5fDl/uPFInpC3a9uycm0sRyZpF4hheg==}
+
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+    hasBin: true
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -3429,6 +3487,49 @@ snapshots:
   json5@2.2.3: {}
 
   konva@10.2.0: {}
+
+  lefthook-darwin-arm64@2.1.9:
+    optional: true
+
+  lefthook-darwin-x64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.9:
+    optional: true
+
+  lefthook-linux-arm64@2.1.9:
+    optional: true
+
+  lefthook-linux-x64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.9:
+    optional: true
+
+  lefthook-windows-arm64@2.1.9:
+    optional: true
+
+  lefthook-windows-x64@2.1.9:
+    optional: true
+
+  lefthook@2.1.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   lru-cache@11.2.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,4 @@ catalog:
 onlyBuiltDependencies:
   - canvas
   - esbuild
+  - lefthook


### PR DESCRIPTION
Adding [lefthook](https://github.com/evilmartians/lefthook) to catch formatting/linting issues earlier. The biome check is inspired by the [biome docs](https://biomejs.dev/recipes/git-hooks/#lefthook).

lefthook should get installed as a git hook automatically by it's build script, but just in case I added a `prepare` script that will run `lefthook install` (which sets up the git hook). The `prepare` hook will run automatically when `pnpm install` gets run.

Example output:
```
󱐋  nwiborg/commit-hooks [+] NeilWib.org❯git commit -m 'add commit hooks'
╭─────────────────────────────────────────╮
│ 🥊 lefthook  v2.1.9   hook:  pre-commit │
╰─────────────────────────────────────────╯
│  typecheck (skip) no matching staged files
┃  check ❯
Checked 3 files in 9ms. Fixed 1 file.

  ────────────────────────────────────
summary: (done in 0.38 seconds)
✔️ check (0.37 seconds)
[nwiborg/commit-hooks 04f3da3] add commit hooks
 6 files changed, 126 insertions(+), 7 deletions(-)
 create mode 100644 lefthook.yml
```