### PR TITLE
chore: add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+      - name: Run Biome
+        run: biome ci .
+  typecheck:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          cache: true
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Check types
+        run: pnpm typecheck


### PR DESCRIPTION
Adding GitHub Actions to do linting in CI, similarly to the commit hooks I [just added](https://github.com/neilwiborg/NeilWib.org/pull/72).

The format/lint job is configured as recommended in the [Biome docs](https://biomejs.dev/recipes/continuous-integration/). It runs on `ubuntu-slim` since it is a lightweight job. The typecheck job runs on `ubuntu-latest` since it needs to install dependencies and requires binaries to be pre-installed on the system.

The jobs run with a GitHub token that only has permission to read the repo, and the token is not persisted after the checkout step, so no scripts from the other steps have access to the repo token.