### PR TITLE
chore: add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,36 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended", "customManagers:biomeVersions"],
+	"enabledManagers": ["nvm", "npm", "github-actions", "custom.jsonata"],
+	"labels": ["dependencies"],
+	"dependencyDashboard": true,
+	"timezone": "America/Los_Angeles",
+	"rangeStrategy": "bump",
+	"schedule": ["before 5am on saturday"],
+	"packageRules": [
+		{
+			"groupName": "frontend dependencies",
+			"matchFileNames": ["frontend/package.json"],
+			"groupSingleUpdates": true,
+			"separateMajorMinor": false
+		},
+		{
+			"groupName": "backend dependencies",
+			"matchFileNames": ["backend/package.json"],
+			"groupSingleUpdates": true,
+			"separateMajorMinor": false
+		},
+		{
+			"groupName": "monorepo dependencies",
+			"matchFileNames": [
+				"package.json",
+				"pnpm-workspace.yaml",
+				"biome.json",
+				".nvmrc",
+				".github/workflows/**"
+			],
+			"groupSingleUpdates": true,
+			"separateMajorMinor": false
+		}
+	]
+}


### PR DESCRIPTION
Adding a config for Renovate, similar to the one I have for NeilBot. It will group dependencies into three PRs for bumping: one for frontend-only dependencies, one for backend-only dependencies, and one for monorepo dependencies.

Validated the config (according to the [docs](https://docs.renovatebot.com/config-validation/)):
```
󱐋  nwiborg/renovate NeilWib.org❯npx --yes --package renovate -- renovate-config-validator
npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
npm warn deprecated glob@10.5.0: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 INFO: Validating .github/renovate.json
 INFO: Config validated successfully against 1 file(s)
```