### PR TITLE
fix: use older postcss version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1743,8 +1743,8 @@ packages:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -3925,7 +3925,7 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
 
-  postcss@8.5.16:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -4279,7 +4279,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.15
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
The [security fix Renovate PR](https://github.com/neilwiborg/NeilWib.org/pull/75) was made before the [Renovate PR that bumped pnpm](https://github.com/neilwiborg/NeilWib.org/pull/77) to version 11 was merged. The new pnpm version requires that packages are at least one day old, and the security fix PR included a brand new version of postcss, which caused CI to start failing after the security fix was merged.

I fixed this by temporarily adding the following to `pnpm-workspace.yaml`:
```
trustLockfile: true

overrides:
  postcss: 8.5.15
```

Then I ran `pnpm install` to update the `pnpm-lock.yaml` and then I reverted the changes to the `pnpm-workspace.yaml`.