### PR TITLE
fix: biome not found by lefthook

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,6 @@
 		"unsplash-js": "^7.0.20"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "catalog:",
 		"@types/cookie-parser": "^1.4.10",
 		"@types/cors": "^2.8.19",
 		"@types/express": "^5.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
 		"zustand": "^5.0.14"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "catalog:",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"typecheck": "pnpm -r typecheck"
 	},
 	"devDependencies": {
+		"@biomejs/biome": "^2.5.1",
 		"lefthook": "^2.1.9"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@biomejs/biome':
-      specifier: ^2.5.1
-      version: 2.5.1
     dotenv:
       specifier: ^17.4.2
       version: 17.4.2
@@ -23,6 +20,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.5.1
+        version: 2.5.1
       lefthook:
         specifier: ^2.1.9
         version: 2.1.9
@@ -60,9 +60,6 @@ importers:
         specifier: ^7.0.20
         version: 7.0.20
     devDependencies:
-      '@biomejs/biome':
-        specifier: 'catalog:'
-        version: 2.5.1
       '@types/cookie-parser':
         specifier: ^1.4.10
         version: 1.4.10(@types/express@5.0.6)
@@ -118,9 +115,6 @@ importers:
         specifier: ^5.0.14
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)
     devDependencies:
-      '@biomejs/biome':
-        specifier: 'catalog:'
-        version: 2.5.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,6 @@ packages:
   - frontend
 
 catalog:
-  "@biomejs/biome": ^2.5.1
   dotenv: ^17.4.2
   tslib: ^2.8.1
   typescript: ^6.0.3


### PR DESCRIPTION
When running the pre-commit hooks, lefthook is not able to find the biome binary because it's installed in each workspace, but not in the repo root.

I have moved biome to the repo root since it is just a formatter/linter for the whole repo anyway, and that is also where the biome config already is. The workspaces still have their own individual scripts for linting and formatting.