### PR TITLE
chore: remove dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,9 +16,8 @@
 		"@aws-sdk/client-dynamodb": "^3.1004.0",
 		"cookie-parser": "^1.4.7",
 		"cors": "^2.8.6",
-		"dotenv": "catalog:",
+		"dotenv": "^17.4.2",
 		"express": "^5.2.1",
-		"http-errors": "^2.0.1",
 		"jsdom": "^28.1.0",
 		"pino": "^10.3.1",
 		"pino-http": "^11.0.0",
@@ -28,11 +27,9 @@
 		"@types/cookie-parser": "^1.4.10",
 		"@types/cors": "^2.8.19",
 		"@types/express": "^5.0.6",
-		"@types/http-errors": "^2.0.5",
 		"@types/jsdom": "^28.0.0",
 		"@types/node": "^25.3.5",
 		"pino-pretty": "^13.1.3",
-		"tslib": "catalog:",
 		"tsx": "^4.21.0",
 		"typescript": "catalog:"
 	}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -8,7 +8,6 @@
 		"types": ["node"],
 		"outDir": "./build",
 		"noEmitOnError": true,
-		"importHelpers": true,
 		"esModuleInterop": true
 	},
 	"include": ["src"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,6 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"dotenv": "catalog:",
 		"konva": "^10.3.0",
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",
@@ -25,7 +24,6 @@
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.3",
-		"tslib": "catalog:",
 		"typescript": "catalog:",
 		"vite": "^8.1.0"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,6 @@ settings:
 
 catalogs:
   default:
-    dotenv:
-      specifier: ^17.4.2
-      version: 17.4.2
-    tslib:
-      specifier: ^2.8.1
-      version: 2.8.1
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -39,14 +33,11 @@ importers:
         specifier: ^2.8.6
         version: 2.8.6
       dotenv:
-        specifier: 'catalog:'
+        specifier: ^17.4.2
         version: 17.4.2
       express:
         specifier: ^5.2.1
         version: 5.2.1
-      http-errors:
-        specifier: ^2.0.1
-        version: 2.0.1
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0(canvas@3.2.1)
@@ -69,9 +60,6 @@ importers:
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
-      '@types/http-errors':
-        specifier: ^2.0.5
-        version: 2.0.5
       '@types/jsdom':
         specifier: ^28.0.0
         version: 28.0.0
@@ -81,9 +69,6 @@ importers:
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -93,9 +78,6 @@ importers:
 
   frontend:
     dependencies:
-      dotenv:
-        specifier: 'catalog:'
-        version: 17.4.2
       konva:
         specifier: ^10.3.0
         version: 10.3.0
@@ -124,9 +106,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.0(@types/node@25.3.5)(esbuild@0.27.7)(tsx@4.21.0))
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,6 @@ packages:
   - frontend
 
 catalog:
-  dotenv: ^17.4.2
-  tslib: ^2.8.1
   typescript: ^6.0.3
 
 allowBuilds:


### PR DESCRIPTION
There are some dependencies that are not currently being used.

The `dotenv` package is only used by the backend, but was included in both the backend and frontend.

`tslib` was not being used by the frontend since it does not emit from the TypeScript compiler. The backend is targeting `ESNext`, so the `importHelpers` option that uses `tslib` was not useful as there were no polyfills. The `importHelpers` option has been removed along with `tslib`.

The `http-errors` package was not being used by the backend, so it has been removed.