### PR TITLE
fix: Renovate does not respect pnpm min age

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,8 @@
 	"dependencyDashboard": true,
 	"timezone": "America/Los_Angeles",
 	"rangeStrategy": "bump",
+	"minimumReleaseAge": "1 day",
+	"internalChecksFilter": "strict",
 	"schedule": ["before 5am on saturday"],
 	"packageRules": [
 		{

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ packages:
 catalog:
   typescript: ^6.0.3
 
+minimumReleaseAge: 1440 # one day
+minimumReleaseAgeStrict: false
+
 allowBuilds:
   canvas: true
   esbuild: true


### PR DESCRIPTION
As of pnpm v11, the default minimum package age is set to one day. This means pnpm will not download packages that are more recent, to attempt to avoid supply chain attacks. The Renovate configuration does _not_ default to a minimum release age, so Renovate was attempting to bump packages to versions that pnpm was rejecting.

The fix is to explicitly configure both pnpm and Renovate with the same minimum release age.

See [here](https://pnpm.io/settings/dependency-resolution) for the relevant pnpm docs and [here](https://docs.renovatebot.com/key-concepts/minimum-release-age/) for the relevant Renovate docs.